### PR TITLE
[Feat] #62 - 상세보기 API 변동사항 반영

### DIFF
--- a/ZOOC/ZOOC/Global/Constant/URLs.swift
+++ b/ZOOC/ZOOC/Global/Constant/URLs.swift
@@ -30,6 +30,7 @@ public enum URLs{
     static let postRecord = "/record/{familyId}"
     static let postMission = "/record/{familyId}?missionId={missionId}"
     static let detailRecord = "/record/detail/{familyId}/{recordId}"
+    static let detailPetRecord = "/record/detail/{familyId}/{petId}/{recordId}"
     static let totalRecord = "/record/{familyId}/{petId}"
     static let deleteRecord = "/record/{recordId}"
     

--- a/ZOOC/ZOOC/Network/Base/APIConstants.swift
+++ b/ZOOC/ZOOC/Network/Base/APIConstants.swift
@@ -13,7 +13,7 @@ struct APIConstants{
     static let contentType = "Content-Type"
     static let applicationJSON = "application/json"
     static let auth = "Authorization"
-    static let accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjE3LCJpYXQiOjE2NzM0NjMzMTIsImV4cCI6MTY3NDA2ODExMn0.9ZTqlzqI4jDsSnO9yHPP2pzOjmDRqs17KaQkm3yHr1c"
+    static let accessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjE3LCJpYXQiOjE2NzM0NjMzMTIsImV4cCI6MTgwMDAwMDAwMH0.mg8gzpzGvaAcJqCgi1QgaYGDZmsRpA184KNtPmYUch4"
     
 //
     

--- a/ZOOC/ZOOC/Network/Home/HomeAPI.swift
+++ b/ZOOC/ZOOC/Network/Home/HomeAPI.swift
@@ -59,6 +59,14 @@ extension HomeAPI{
             self.disposeNetwork(result, dataModel: [CommentResult].self, completion: completion)
         }
     }
+    
+    func getNewDetailArchive(recordID: String, petID: String ,completion: @escaping (NetworkResult<Any>) -> Void) {
+        homeProvider.request(.getNewDetailArchive(familyID: User.familyID, recordID: recordID, petID: petID)) { (result) in
+            self.disposeNetwork(result,
+                                dataModel: HomeDetailArchiveResult.self,
+                                completion: completion)
+        }
+    }
 }
 
 

--- a/ZOOC/ZOOC/Network/Home/HomeAPI.swift
+++ b/ZOOC/ZOOC/Network/Home/HomeAPI.swift
@@ -60,8 +60,8 @@ extension HomeAPI{
         }
     }
     
-    func getNewDetailArchive(recordID: String, petID: String ,completion: @escaping (NetworkResult<Any>) -> Void) {
-        homeProvider.request(.getNewDetailArchive(familyID: User.familyID, recordID: recordID, petID: petID)) { (result) in
+    func getDetailPetArchive(recordID: String, petID: String ,completion: @escaping (NetworkResult<Any>) -> Void) {
+        homeProvider.request(.getDetailPetArchive(familyID: User.familyID, recordID: recordID, petID: petID)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: HomeDetailArchiveResult.self,
                                 completion: completion)

--- a/ZOOC/ZOOC/Network/Home/HomeService.swift
+++ b/ZOOC/ZOOC/Network/Home/HomeService.swift
@@ -14,7 +14,7 @@ enum HomeService {
     case getTotalPet(familyID: String)
     case getTotalArchive(familyID: String,petID: String)
     case getDetailArchive(familyID: String, recordID: String)
-    case getNewDetailArchive(familyID: String, recordID: String, petID: String)
+    case getDetailPetArchive(familyID: String, recordID: String, petID: String)
     case getNotice
     case postComment(recordID: String, comment: String)
 }
@@ -23,20 +23,39 @@ extension HomeService: BaseTargetType {
      
     var path: String {
         switch self {
+            
         case .getMission(let familyID):
-            return URLs.getMission.replacingOccurrences(of: "{familyId}", with: familyID)
+            return URLs.getMission
+                .replacingOccurrences(of: "{familyId}", with: familyID)
+            
         case .getTotalPet(let familyID):
-            return URLs.totalPet.replacingOccurrences(of: "{familyId}", with: familyID)
+            return URLs.totalPet
+                .replacingOccurrences(of: "{familyId}", with: familyID)
+            
         case .getTotalArchive(familyID: let familyID, petID: let petID):
-            return URLs.totalRecord.replacingOccurrences(of: "{familyId}", with: familyID).replacingOccurrences(of: "{petId}", with: petID)
+            return URLs.totalRecord
+                .replacingOccurrences(of: "{familyId}", with: familyID)
+                .replacingOccurrences(of: "{petId}", with: petID)
+            
         case .getDetailArchive(familyID: let familyID, recordID: let recordID):
-            return URLs.detailRecord.replacingOccurrences(of: "{familyId}", with: familyID).replacingOccurrences(of: "{recordId}", with: recordID)
+            return URLs.detailRecord
+                .replacingOccurrences(of: "{familyId}", with: familyID)
+                .replacingOccurrences(of: "{recordId}", with: recordID)
+            
         case .getNotice:
             return URLs.getNotice
-        case .postComment(recordID: let recordID, comment: let comment):
-            return URLs.postComment.replacingOccurrences(of: "{recordId}", with: recordID)
-        case .getNewDetailArchive(familyID: let familyID, recordID: let recordID, petID: let petID):
-            return "/record/detail/{familyId}/{petId}/{recordId}".replacingOccurrences(of: "{familyId}", with: familyID).replacingOccurrences(of: "{petId}", with: petID).replacingOccurrences(of: "{recordId}", with: recordID)
+            
+        case .postComment(recordID: let recordID, comment: _):
+            return URLs.postComment
+                .replacingOccurrences(of: "{recordId}", with: recordID)
+            
+        case .getDetailPetArchive(familyID: let familyID,
+                                  recordID: let recordID,
+                                  petID: let petID):
+            return URLs.detailPetRecord
+                .replacingOccurrences(of: "{familyId}", with: familyID)
+                .replacingOccurrences(of: "{petId}", with: petID)
+                .replacingOccurrences(of: "{recordId}", with: recordID)
         }
     }
         
@@ -54,7 +73,7 @@ extension HomeService: BaseTargetType {
             return .get
         case .postComment:
             return .post
-        case .getNewDetailArchive:
+        case .getDetailPetArchive:
             return .get
         }
     }
@@ -71,10 +90,10 @@ extension HomeService: BaseTargetType {
             return .requestPlain
         case .getNotice:
             return .requestPlain
-        case .postComment(recordID: let recordID, comment: let comment):
+        case .postComment(recordID: _, comment: let comment):
             let body = HomeCommentReqeust(content: comment)
             return .requestJSONEncodable(body)
-        case .getNewDetailArchive(familyID: let familyID, recordID: let recordID, petID: let petID):
+        case .getDetailPetArchive:
             return .requestPlain
         }
     }

--- a/ZOOC/ZOOC/Network/Home/HomeService.swift
+++ b/ZOOC/ZOOC/Network/Home/HomeService.swift
@@ -14,6 +14,7 @@ enum HomeService {
     case getTotalPet(familyID: String)
     case getTotalArchive(familyID: String,petID: String)
     case getDetailArchive(familyID: String, recordID: String)
+    case getNewDetailArchive(familyID: String, recordID: String, petID: String)
     case getNotice
     case postComment(recordID: String, comment: String)
 }
@@ -34,6 +35,8 @@ extension HomeService: BaseTargetType {
             return URLs.getNotice
         case .postComment(recordID: let recordID, comment: let comment):
             return URLs.postComment.replacingOccurrences(of: "{recordId}", with: recordID)
+        case .getNewDetailArchive(familyID: let familyID, recordID: let recordID, petID: let petID):
+            return "/record/detail/{familyId}/{petId}/{recordId}".replacingOccurrences(of: "{familyId}", with: familyID).replacingOccurrences(of: "{petId}", with: petID).replacingOccurrences(of: "{recordId}", with: recordID)
         }
     }
         
@@ -51,6 +54,8 @@ extension HomeService: BaseTargetType {
             return .get
         case .postComment:
             return .post
+        case .getNewDetailArchive:
+            return .get
         }
     }
     
@@ -69,6 +74,8 @@ extension HomeService: BaseTargetType {
         case .postComment(recordID: let recordID, comment: let comment):
             let body = HomeCommentReqeust(content: comment)
             return .requestJSONEncodable(body)
+        case .getNewDetailArchive(familyID: let familyID, recordID: let recordID, petID: let petID):
+            return .requestPlain
         }
     }
 }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
@@ -155,6 +155,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
     private func register(){
         commentCollectionView.register(HomeCommentCollectionViewCell.self,
                                        forCellWithReuseIdentifier: HomeCommentCollectionViewCell.cellIdentifier)
+        
         commentCollectionView.delegate = self
         commentCollectionView.dataSource = self
         
@@ -286,47 +287,13 @@ final class HomeDetailArchiveViewController : BaseViewController{
         
     }
     
-    func getAPI(recordID: String){
-        HomeAPI.shared.getDetailArchive(recordID: recordID) { result in
-            guard let result = self.validateResult(result) as?  HomeDetailArchiveResult else { return }
-            
-            self.detailArchiveData = result
-            if let imageURL = result.record.writerPhoto{
-                self.writerImageView.kfSetImage(url: imageURL)
-                
-            }
-            else {
-                self.writerImageView.image = Image.defaultProfile
-            }
-            
-            self.petImageView.kfSetImage(url: result.record.photo)
-            self.dateLabel.text = result.record.date
-            self.writerNameLabel.text = result.record.writerName
-            self.contentLabel.text = result.record.content
-            self.commentData = result.comments
-            self.commentCollectionView.reloadData()
-            
-            DispatchQueue.main.async {
-                self.commentCollectionView.snp.remakeConstraints {
-                    $0.top.equalTo(self.lineView.snp.bottom)
-                    $0.leading.trailing.equalToSuperview()
-                    $0.bottom.equalToSuperview()
-                    $0.height.equalTo(self.commentCollectionView.contentSize.height)
-                }
-                self.view.layoutIfNeeded()
-            }
-        }
-        
-    }
-    
     func getAPI(recordID: String, petID: String){
-        HomeAPI.shared.getNewDetailArchive(recordID: recordID, petID: petID) { result in
+        HomeAPI.shared.getDetailPetArchive(recordID: recordID, petID: petID) { result in
             guard let result = self.validateResult(result) as?  HomeDetailArchiveResult else { return }
             
             self.detailArchiveData = result
             if let imageURL = result.record.writerPhoto{
                 self.writerImageView.kfSetImage(url: imageURL)
-                
             }
             else {
                 self.writerImageView.image = Image.defaultProfile
@@ -349,24 +316,6 @@ final class HomeDetailArchiveViewController : BaseViewController{
                 self.view.layoutIfNeeded()
             }
         }
-        
-    }
-    
-    private func pushToDetailViewController(recordID: String){
-        let viewController = HomeDetailArchiveViewController()
-        viewController.getAPI(recordID: recordID)
-        viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: false) {
-            self.dismiss(animated: false)
-        }
-    }
-    
-    private func pushToDetailViewController(recordID: String,petID:String){
-      let viewController = HomeDetailArchiveViewController()
-        viewController.petID = petID
-        viewController.getAPI(recordID: recordID, petID: petID)
-        viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: false)
         
     }
     
@@ -387,18 +336,17 @@ final class HomeDetailArchiveViewController : BaseViewController{
         switch sender.tag{
         case 0:
             if let id = detailArchiveData?.leftID {
-//                pushToDetailViewController(recordID: String(id))
-                pushToDetailViewController(recordID: String(id),petID: petID)
+                getAPI(recordID: String(id), petID: petID)
             } else {
                 presentBottomAlert("마지막 페이지 입니다.")
             }
         case 1:
             if let id = detailArchiveData?.rightID{
-                pushToDetailViewController(recordID: String(id),petID: petID)
+                getAPI(recordID: String(id), petID: petID)
             }else {
                 presentBottomAlert("마지막 페이지 입니다.")
             }
-        default: print("directionButtonDidTap 디폴트에 진입했씁니다.")
+        default: print("directionButtonDidTap 디폴트에 진입했씁니다. 오류임!")
         }
     }
     
@@ -470,9 +418,6 @@ extension HomeDetailArchiveViewController: CommentTextFieldDelegate{
         }
     }
     
-    func textFieldDidBeginEditing(_ textField: UITextField) {
-        textField.isUserInteractionEnabled = true
-    }
     
     
 }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
@@ -13,7 +13,7 @@ import Then
 final class HomeDetailArchiveViewController : BaseViewController{
     
     //MARK: - Properties
-    
+    var petID: String = "1"
     private var detailArchiveMockData: HomeDetailArchiveModel = HomeDetailArchiveModel.mockData
     
     private var detailArchiveData: HomeDetailArchiveResult?
@@ -319,11 +319,55 @@ final class HomeDetailArchiveViewController : BaseViewController{
         
     }
     
+    func getAPI(recordID: String, petID: String){
+        HomeAPI.shared.getNewDetailArchive(recordID: recordID, petID: petID) { result in
+            guard let result = self.validateResult(result) as?  HomeDetailArchiveResult else { return }
+            
+            self.detailArchiveData = result
+            if let imageURL = result.record.writerPhoto{
+                self.writerImageView.kfSetImage(url: imageURL)
+                
+            }
+            else {
+                self.writerImageView.image = Image.defaultProfile
+            }
+            
+            self.petImageView.kfSetImage(url: result.record.photo)
+            self.dateLabel.text = result.record.date
+            self.writerNameLabel.text = result.record.writerName
+            self.contentLabel.text = result.record.content
+            self.commentData = result.comments
+            self.commentCollectionView.reloadData()
+            
+            DispatchQueue.main.async {
+                self.commentCollectionView.snp.remakeConstraints {
+                    $0.top.equalTo(self.lineView.snp.bottom)
+                    $0.leading.trailing.equalToSuperview()
+                    $0.bottom.equalToSuperview()
+                    $0.height.equalTo(self.commentCollectionView.contentSize.height)
+                }
+                self.view.layoutIfNeeded()
+            }
+        }
+        
+    }
+    
     private func pushToDetailViewController(recordID: String){
         let viewController = HomeDetailArchiveViewController()
         viewController.getAPI(recordID: recordID)
         viewController.modalPresentationStyle = .fullScreen
+        present(viewController, animated: false) {
+            self.dismiss(animated: false)
+        }
+    }
+    
+    private func pushToDetailViewController(recordID: String,petID:String){
+      let viewController = HomeDetailArchiveViewController()
+        viewController.petID = petID
+        viewController.getAPI(recordID: recordID, petID: petID)
+        viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: false)
+        
     }
     
     //MARK: - Action Method
@@ -343,13 +387,14 @@ final class HomeDetailArchiveViewController : BaseViewController{
         switch sender.tag{
         case 0:
             if let id = detailArchiveData?.leftID {
-                pushToDetailViewController(recordID: String(id))
+//                pushToDetailViewController(recordID: String(id))
+                pushToDetailViewController(recordID: String(id),petID: petID)
             } else {
                 presentBottomAlert("마지막 페이지 입니다.")
             }
         case 1:
             if let id = detailArchiveData?.rightID{
-                pushToDetailViewController(recordID: String(id))
+                pushToDetailViewController(recordID: String(id),petID: petID)
             }else {
                 presentBottomAlert("마지막 페이지 입니다.")
             }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
@@ -31,11 +31,11 @@ final class HomeDetailArchiveViewController : BaseViewController{
     }()
     private let contentView = UIView()
     
-    private lazy var dismissButton: UIButton = {
+    private lazy var backButton: UIButton = {
         let button = UIButton()
-        button.setImage(Image.xmark, for: .normal)
+        button.setImage(Image.back, for: .normal)
         button.addTarget(self,
-                         action: #selector(dismissButtonDidTap),
+                         action: #selector(backButtonDidTap),
                          for: .touchUpInside)
         return button
     }()
@@ -181,7 +181,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
         
         contentView.addSubviews(
                                  petImageView,
-                                 dismissButton,
+                                 backButton,
                                  etcButton,
                                  previousButton,
                                  nextButton,
@@ -220,7 +220,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
         }
         
         //MARK: ContentView Layout
-        dismissButton.snp.makeConstraints {
+        backButton.snp.makeConstraints {
             $0.top.equalToSuperview().offset(53)
             $0.leading.equalToSuperview().offset(16)
             $0.height.width.equalTo(42)
@@ -322,8 +322,8 @@ final class HomeDetailArchiveViewController : BaseViewController{
     //MARK: - Action Method
     
     @objc
-    func dismissButtonDidTap(){
-        dismiss(animated: true)
+    func backButtonDidTap(){
+        navigationController?.popViewController(animated: true)
     }
     
     @objc
@@ -417,8 +417,4 @@ extension HomeDetailArchiveViewController: CommentTextFieldDelegate{
             }
         }
     }
-    
-    
-    
 }
-

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -116,24 +116,6 @@ final class HomeViewController : BaseViewController{
         updateAPI()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-    }
-    
-    
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-//        petData = []
-//        archiveData = []
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        //updateIndicatorView(archiveListCollectionView)
-    }
-    
     //MARK: - Custom Method
     
     private func register(){
@@ -251,8 +233,18 @@ final class HomeViewController : BaseViewController{
     }
     
     private func pushToDetailViewController(recordID: String){
+        guard let index = petCollectionView.indexPathsForSelectedItems?[0].row else {
+            presentBottomAlert("선택된 펫이 없습니다.")
+            return
+        }
+        
         let viewController = HomeDetailArchiveViewController()
-        viewController.getAPI(recordID: recordID)
+        let petID = String(petData[index].id)
+        viewController.petID = petID
+        //viewController.getAPI(recordID: recordID)
+        viewController.getAPI(recordID: recordID, petID: petID)
+        
+        
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: false)
     }
@@ -276,6 +268,7 @@ final class HomeViewController : BaseViewController{
                                          scrollPosition: .centeredHorizontally)
             petCollectionView.performBatchUpdates(nil)
             getTotalArchive(petID: petData[0].id)
+            
             updateIndicatorView(self.archiveListCollectionView)
         }
     }
@@ -390,7 +383,6 @@ extension HomeViewController: UICollectionViewDataSource{
         
         if collectionView == petCollectionView{
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomePetCollectionViewCell.cellIdentifier, for: indexPath) as?  HomePetCollectionViewCell else { return UICollectionViewCell() }
-            //cell.dataBind(data: petMockData[indexPath.item])
             cell.dataBind(data: petData[indexPath.item])
             return cell
         }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -238,18 +238,19 @@ final class HomeViewController : BaseViewController{
             return
         }
         
-        let viewController = HomeDetailArchiveViewController()
+        let detailVC = HomeDetailArchiveViewController()
         let petID = String(petData[index].id)
-        viewController.petID = petID
-        viewController.getAPI(recordID: recordID, petID: petID)
+        detailVC.petID = petID
+        detailVC.getAPI(recordID: recordID, petID: petID)
         
-        viewController.modalPresentationStyle = .fullScreen
-        present(viewController, animated: false)
+        detailVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(detailVC, animated: true)
     }
     
     private func pushToHomeAlarmViewController(){
-        let viewController = HomeNoticeViewController()
-        navigationController?.pushViewController(viewController, animated: true)
+        let noticeVC = HomeNoticeViewController()
+        noticeVC.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(noticeVC, animated: true)
     }
     
     private func foldArchiveCollectionView(){

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -241,9 +241,7 @@ final class HomeViewController : BaseViewController{
         let viewController = HomeDetailArchiveViewController()
         let petID = String(petData[index].id)
         viewController.petID = petID
-        //viewController.getAPI(recordID: recordID)
         viewController.getAPI(recordID: recordID, petID: petID)
-        
         
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: false)


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #62

### ✅ 작업한 내용
- 상세보기뷰에서 다음, 이전 버튼 클릭시 보여지는 상세보기뷰에 특정 pet만 보여지게 구현

### ❗️PR Point
- 화면 전환 present 보다 push가 더 자연스러워 보여 push로 화면전환 함
- HomeAPI에서 detailRecord(구) 와 detailPetRecord(신) API가 있으나 실제 사용하는건 후자임.
- detailRecordAPI는 서버측에서 더이상 사용하지 않는다는 답변 받으면 삭제 예정
- 

### 📸 스크린샷
![상세보기 gif](https://user-images.githubusercontent.com/57269348/213844341-c362ea5f-da21-47f3-aa84-942d203e2934.gif)


closed #62 
