### PR TITLE
[Refactor] #64 - 홈뷰 코드 리팩토링 

### DIFF
--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4C8A7C33297063F400783979 /* OnboardingInviteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */; };
 		4C94035E2962F5470003A9BF /* MyFamilyInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C94035D2962F5470003A9BF /* MyFamilyInviteViewController.swift */; };
 		4C9403602964695A0003A9BF /* MyInviteCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C94035F2964695A0003A9BF /* MyInviteCompleteViewController.swift */; };
+		870D062A297BEB7900ADAD04 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870D0629297BEB7900ADAD04 /* HomeView.swift */; };
 		871EA33C296F3E6200D0E8CC /* HomePetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33B296F3E6200D0E8CC /* HomePetResult.swift */; };
 		871EA33E296F529C00D0E8CC /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33D296F529C00D0E8CC /* UIImageView+.swift */; };
 		871EA340296F6E5000D0E8CC /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33F296F6E5000D0E8CC /* BaseAPI.swift */; };
@@ -174,6 +175,7 @@
 		4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteResult.swift; sourceTree = "<group>"; };
 		4C94035D2962F5470003A9BF /* MyFamilyInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFamilyInviteViewController.swift; sourceTree = "<group>"; };
 		4C94035F2964695A0003A9BF /* MyInviteCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInviteCompleteViewController.swift; sourceTree = "<group>"; };
+		870D0629297BEB7900ADAD04 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		871EA33B296F3E6200D0E8CC /* HomePetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetResult.swift; sourceTree = "<group>"; };
 		871EA33D296F529C00D0E8CC /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		871EA33F296F6E5000D0E8CC /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
@@ -517,6 +519,7 @@
 		8782C7E82969502600C9324B /* View */ = {
 			isa = PBXGroup;
 			children = (
+				870D0629297BEB7900ADAD04 /* HomeView.swift */,
 				8782C7EA296AC58B00C9324B /* HomeArchiveIndicatorView.swift */,
 				8782C7F4296DB7FC00C9324B /* HomeDetailArchiveCommentTextField.swift */,
 				D26C68F32970AD930088DC9A /* HomeNoticeView.swift */,
@@ -1025,6 +1028,7 @@
 				D2F193632970B95E00AD87D3 /* HomeNoticeResult.swift in Sources */,
 				D2F193612970B3FB00AD87D3 /* HomeNoticeModel.swift in Sources */,
 				87D5AF6429649DC100CA7F12 /* HomeViewController.swift in Sources */,
+				870D062A297BEB7900ADAD04 /* HomeView.swift in Sources */,
 				87A76AC32960427C0096F669 /* APIConstants.swift in Sources */,
 				877E57F02966C046006D82FC /* HomeArchiveModel.swift in Sources */,
 				D26C860A296B5C7400AEAF9B /* OnboardingParticipateViewController.swift in Sources */,

--- a/ZOOC/ZOOC/Network/Record/RecordAPI.swift
+++ b/ZOOC/ZOOC/Network/Record/RecordAPI.swift
@@ -30,7 +30,7 @@ extension RecordAPI{
                                            pets: pets))
         { result in
             self.disposeNetwork(result,
-                                dataModel: MyResult.self,
+                                dataModel: SimpleResponse.self,
                                 completion: completion)
         }
     }

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveGridCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveGridCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class HomeArchiveGridCollectionViewCell : UICollectionViewCell{
+final class HomeArchiveGridCollectionViewCell : UICollectionViewCell {
     
     //MARK: - Properties
     
@@ -36,13 +36,13 @@ final class HomeArchiveGridCollectionViewCell : UICollectionViewCell{
     }
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         contentView.backgroundColor = .zoocWhite1
         contentView.layer.cornerRadius = 12
         contentView.clipsToBounds = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(petImageView)
        
         petImageView.snp.makeConstraints {
@@ -51,11 +51,11 @@ final class HomeArchiveGridCollectionViewCell : UICollectionViewCell{
     
     }
     
-    func dataBind(data: HomeArchiveModel){
+    func dataBind(data: HomeArchiveModel) {
         petImageView.image = data.petImage
     }
     
-    func dataBind(data: HomeArchiveResult){
+    func dataBind(data: HomeArchiveResult) {
         petImageView.kfSetImage(url: data.record.photo)
     }
     

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveListCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveListCollectionViewCell.swift
@@ -22,10 +22,10 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
     
     public var viewType : ViewType = .folded
     
-    override var isSelected: Bool{
-        didSet{
-            if isSelected{
-                switch viewType{
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                switch viewType {
                 case .folded:
                     viewType = .expanded
                     updateUI()
@@ -33,7 +33,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
                  break
                 }
             } else{
-                switch viewType{
+                switch viewType {
                 case .folded:
                     break
                 case .expanded:
@@ -126,20 +126,20 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
     
     //MARK: - Custom Method
     
-    private func register(){
+    private func register() {
         writerCollectionView.delegate = self
         writerCollectionView.dataSource = self
         
         writerCollectionView.register(HomeArchiveListWriterCollectionViewCell.self, forCellWithReuseIdentifier: HomeArchiveListWriterCollectionViewCell.cellIdentifier)
     }
     
-    private func setUI(){
+    private func setUI() {
         contentView.backgroundColor = .zoocWhite1
         contentView.layer.cornerRadius = 12
         contentView.clipsToBounds = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(petImageView,
                                 writerCollectionView,
                                 writerProfileImageView,
@@ -184,32 +184,32 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
     
     }
     
-    private func foldedLayout(){
+    private func foldedLayout() {
         writerCollectionView.isHidden = true
         contentLabel.isHidden = true
         writerLabel.isHidden = true
     }
     
-    private func foldedAlpha(){
+    private func foldedAlpha() {
         writerCollectionView.alpha = 0
         contentLabel.alpha = 0
         writerLabel.alpha = 0
     }
 
     
-    private func expandedLayout(){
+    private func expandedLayout() {
         writerCollectionView.isHidden = false
         contentLabel.isHidden = false
         writerLabel.isHidden = false
     }
     
-    private func expandedAlpha(){
+    private func expandedAlpha() {
         writerCollectionView.alpha = 1
         contentLabel.alpha = 1
         writerLabel.alpha = 1
     }
     
-    private func foldedAnimatedLayout(){
+    private func foldedAnimatedLayout() {
         self.writerProfileImageView.snp.remakeConstraints {
             $0.top.equalTo(self.petImageView.snp.bottom).offset(84)
             $0.centerX.equalToSuperview()
@@ -222,7 +222,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
         }
     }
     
-    private func expandedFirstAnimatedLayout(){
+    private func expandedFirstAnimatedLayout() {
         self.writerProfileImageView.snp.remakeConstraints {
             $0.leading.equalToSuperview().offset(18)
             $0.bottom.equalToSuperview().offset(-20)
@@ -235,7 +235,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
         }
     }
     
-    private func expandedSecondAnimatedLayout(){
+    private func expandedSecondAnimatedLayout() {
         
         self.expandedLayout()
         UIView.animate(withDuration: 0.2) {
@@ -254,7 +254,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
             $0.width.equalTo(writerLabel.intrinsicContentSize.width + 14)
         }
     }
-    private func updateUI(){
+    private func updateUI() {
         
         switch viewType{
             
@@ -276,7 +276,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
         }
     }
     
-    func dataBind(data: HomeArchiveModel){
+    func dataBind(data: HomeArchiveModel) {
         petImageView.image = data.petImage
         contentLabel.text = data.content
         writerProfileImageView.image = data.profileImage
@@ -284,7 +284,7 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
         dateLabel.text = data.date
     }
     
-    func dataBind(data: HomeArchiveResult){
+    func dataBind(data: HomeArchiveResult) {
         
         if data.record.writerPhoto == nil {
             self.writerProfileImageView.image = Image.defaultProfile
@@ -304,26 +304,14 @@ final class HomeArchiveListCollectionViewCell : UICollectionViewCell{
         commentWriterData = data.commentWriters
     }
     
-    func resizeImage(image: UIImage, newWidth: CGFloat) -> UIImage {
-
-        let scale = newWidth / image.size.width
-        let newHeight = image.size.height * scale
-        UIGraphicsBeginImageContext(CGSize(width: newWidth, height: newHeight))
-        image.draw(in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return newImage!
-    }
-    
-    func updateWriterCollectionViewCell(){
+    func updateWriterCollectionViewCell() {
         writerCollectionView.reloadData()
     }
     
 }
 
 //MARK: - UICollectionViewDataSource
-extension HomeArchiveListCollectionViewCell: UICollectionViewDataSource{
+extension HomeArchiveListCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return commentWriterData.count
     }
@@ -336,7 +324,7 @@ extension HomeArchiveListCollectionViewCell: UICollectionViewDataSource{
 }
 
 //MARK: - UICollectionViewDelegateFlowLayout
-extension HomeArchiveListCollectionViewCell: UICollectionViewDelegateFlowLayout{
+extension HomeArchiveListCollectionViewCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: 20, height: 20)
     }

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveListWriterCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeArchiveListWriterCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class HomeArchiveListWriterCollectionViewCell: UICollectionViewCell{
+final class HomeArchiveListWriterCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
     
@@ -42,12 +42,12 @@ final class HomeArchiveListWriterCollectionViewCell: UICollectionViewCell{
     
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         contentView.layer.cornerRadius = 10
         contentView.layer.masksToBounds = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubview(writerImageView)
         
         writerImageView.snp.makeConstraints {
@@ -55,7 +55,7 @@ final class HomeArchiveListWriterCollectionViewCell: UICollectionViewCell{
         }
     }
     
-    func dataBind(data: CommentWriterResult){
+    func dataBind(data: CommentWriterResult) {
         print(data)
         guard let imageURL = data.writerPhoto else {
             writerImageView.image = Image.defaultProfile

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeCommentCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeCommentCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class HomeCommentCollectionViewCell: UICollectionViewCell{
+final class HomeCommentCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
     
@@ -77,12 +77,12 @@ final class HomeCommentCollectionViewCell: UICollectionViewCell{
     }
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         commentLabel.isHidden = false
         commentEmojiImageView.isHidden = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(writerImageView,
                                 writerLabel,
                                 commentLabel,
@@ -125,16 +125,16 @@ final class HomeCommentCollectionViewCell: UICollectionViewCell{
         }
     }
     
-    func dataBind(data: ArchiveCommentModel){
+    func dataBind(data: ArchiveCommentModel) {
         writerImageView.image = data.writerImage
         writerLabel.text = data.writerName
         commentLabel.text = data.comment
         dateLabel.text = data.date
     }
     
-    func dataBind(data: CommentResult){
-        if data.isEmoji{
-            
+    func dataBind(data: CommentResult) {
+        if data.isEmoji {
+             
             commentLabel.isHidden = true
             commentEmojiImageView.isHidden = false
             
@@ -146,7 +146,7 @@ final class HomeCommentCollectionViewCell: UICollectionViewCell{
             commentLabel.text = data.content
         }
         
-        if let imageURL = data.photo{
+        if let imageURL = data.photo {
             writerImageView.kfSetImage(url: imageURL)
         } else {
             writerImageView.image = Image.defaultProfile

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeGuideCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeGuideCollectionViewCell.swift
@@ -64,7 +64,7 @@ final class HomeGuideCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = 24
         
@@ -74,7 +74,7 @@ final class HomeGuideCollectionViewCell: UICollectionViewCell {
                                opacity: 0.2)
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(titleLabel,descriptionLabel,cardImageView)
         
         titleLabel.snp.makeConstraints {

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeMissionCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeMissionCollectionViewCell.swift
@@ -81,11 +81,11 @@ final class HomeMissionCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Custom Method
     
-    private func setDelegate(){
+    private func setDelegate() {
         textView.delegate = self
     }
     
-    private func setUI(){
+    private func setUI() {
         contentView.backgroundColor = .white
         contentView.layer.cornerRadius = 24
         
@@ -95,7 +95,7 @@ final class HomeMissionCollectionViewCell: UICollectionViewCell {
                                opacity: 0.2)
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(titleLabel,galleryImageView,textView, nextButton)
         
         titleLabel.snp.makeConstraints {
@@ -125,7 +125,7 @@ final class HomeMissionCollectionViewCell: UICollectionViewCell {
     //MARK: - Action Method
     
     @objc
-    private func nextButtonDidTap(){
+    private func nextButtonDidTap() {
         print("delegate로 보내자")
         delegate?.nextButtonDidTap(textView.text)
     }

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomePetCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomePetCollectionViewCell.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-final class HomePetCollectionViewCell: UICollectionViewCell{
+final class HomePetCollectionViewCell: UICollectionViewCell {
     
-    enum ViewType{
+    enum ViewType {
         case folded
         case expanded
     }
@@ -83,7 +83,7 @@ final class HomePetCollectionViewCell: UICollectionViewCell{
     
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         contentView.backgroundColor = .zoocWhite2
         contentView.layer.borderWidth = 1
         contentView.layer.borderColor = UIColor.zoocLightGray.cgColor
@@ -91,7 +91,7 @@ final class HomePetCollectionViewCell: UICollectionViewCell{
         contentView.clipsToBounds = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         contentView.addSubviews(petImageView,petNameLabel)
         updateUI()
     }
@@ -111,9 +111,9 @@ final class HomePetCollectionViewCell: UICollectionViewCell{
         self.petNameLabel.text = data.name
     }
     
-    private func updateUI(){
+    private func updateUI() {
         
-        switch viewType{
+        switch viewType {
         case .folded:
             foldedLayout()
         case .expanded:
@@ -121,7 +121,7 @@ final class HomePetCollectionViewCell: UICollectionViewCell{
         }
     }
     
-    private func foldedLayout(){
+    private func foldedLayout() {
         petImageView.snp.remakeConstraints {
             $0.edges.equalToSuperview()
         }
@@ -129,7 +129,7 @@ final class HomePetCollectionViewCell: UICollectionViewCell{
         
     }
     
-    private func expandedLayout(){
+    private func expandedLayout() {
         petNameLabel.isHidden = false
         
         petImageView.snp.remakeConstraints {

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeDetailArchiveViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HomeDetailArchiveViewController : BaseViewController{
+final class HomeDetailArchiveViewController : BaseViewController {
     
     //MARK: - Properties
     var petID: String = "1"
@@ -152,7 +152,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
 
     //MARK: - Custom Method
     
-    private func register(){
+    private func register() {
         commentCollectionView.register(HomeCommentCollectionViewCell.self,
                                        forCellWithReuseIdentifier: HomeCommentCollectionViewCell.cellIdentifier)
         
@@ -162,7 +162,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
         commentTextField.commentDelegate = self
     }
     
-    private func setUI(){
+    private func setUI() {
 //        petImageView.image = detailArchiveMockData.petImage
 //        dateLabel.text = detailArchiveMockData.date
 //        writerImageView.image = detailArchiveMockData.writerImage
@@ -171,7 +171,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
     }
     
     
-    private func setLayout(){
+    private func setLayout() {
         view.addSubviews(scrollView,
                          commentTextField,
                          commentEmojiButton)
@@ -179,8 +179,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
         scrollView.addSubview(contentView)
         
         
-        contentView.addSubviews(
-                                 petImageView,
+        contentView.addSubviews(petImageView,
                                  backButton,
                                  etcButton,
                                  previousButton,
@@ -190,10 +189,10 @@ final class HomeDetailArchiveViewController : BaseViewController{
                                  writerNameLabel,
                                  contentLabel,
                                  lineView,
-                                 commentCollectionView
-                                )
+                                 commentCollectionView)
         
-        //MARK: View Layout
+        //MARK: view Layout
+        
         scrollView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
         }
@@ -212,14 +211,16 @@ final class HomeDetailArchiveViewController : BaseViewController{
             $0.height.width.equalTo(30)
         }
         
-        //MARK: ScrollView Layout
+        //MARK: scrollView Layout
+        
         contentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.height.greaterThanOrEqualTo(scrollView.contentSize.height).priority(.low)
             $0.width.equalTo(scrollView.snp.width)
         }
         
-        //MARK: ContentView Layout
+        //MARK: contentView Layout
+        
         backButton.snp.makeConstraints {
             $0.top.equalToSuperview().offset(53)
             $0.leading.equalToSuperview().offset(16)
@@ -287,7 +288,7 @@ final class HomeDetailArchiveViewController : BaseViewController{
         
     }
     
-    func getAPI(recordID: String, petID: String){
+    func getAPI(recordID: String, petID: String) {
         HomeAPI.shared.getDetailPetArchive(recordID: recordID, petID: petID) { result in
             guard let result = self.validateResult(result) as?  HomeDetailArchiveResult else { return }
             
@@ -322,17 +323,17 @@ final class HomeDetailArchiveViewController : BaseViewController{
     //MARK: - Action Method
     
     @objc
-    func backButtonDidTap(){
+    func backButtonDidTap() {
         navigationController?.popViewController(animated: true)
     }
     
     @objc
-    func etcButtonDidTap(){
+    func etcButtonDidTap() {
         print("더보기 버튼 눌렸습니다.")
     }
     
     @objc
-    func directionButtonDidTap(_ sender: UIButton){
+    func directionButtonDidTap(_ sender: UIButton) {
         switch sender.tag{
         case 0:
             if let id = detailArchiveData?.leftID {
@@ -351,22 +352,20 @@ final class HomeDetailArchiveViewController : BaseViewController{
     }
     
     @objc
-    func emojiButtonDidTap(){
+    func emojiButtonDidTap() {
         presentBottomAlert("이모지 기능은 곧 만나요~")
     }
 }
 
 //MARK: - UICollectionViewDataSource
-extension HomeDetailArchiveViewController: UICollectionViewDataSource{
+extension HomeDetailArchiveViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView,
-                        numberOfItemsInSection section: Int) -> Int
-    {
+                        numberOfItemsInSection section: Int) -> Int {
         return commentData.count
     }
     
     func collectionView(_ collectionView: UICollectionView,
-                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
-    {
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeCommentCollectionViewCell.cellIdentifier, for: indexPath) as? HomeCommentCollectionViewCell else { return UICollectionViewCell() }
         cell.dataBind(data: commentData[indexPath.row])
         return cell
@@ -375,11 +374,10 @@ extension HomeDetailArchiveViewController: UICollectionViewDataSource{
 
 //MARK: - UICollectionViewDelegateFlowLayout
 
-extension HomeDetailArchiveViewController: UICollectionViewDelegateFlowLayout{
+extension HomeDetailArchiveViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
-                        sizeForItemAt indexPath: IndexPath) -> CGSize
-    {
+                        sizeForItemAt indexPath: IndexPath) -> CGSize {
         let width = collectionView.frame.width - 36        
         if commentData[indexPath.row].isEmoji{
             return CGSize(width: width, height: 126)
@@ -391,13 +389,12 @@ extension HomeDetailArchiveViewController: UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
-                        insetForSectionAt section: Int) -> UIEdgeInsets
-    {
+                        insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 10, left: 18, bottom: 10, right: 18)
     }
 }
 
-extension HomeDetailArchiveViewController: CommentTextFieldDelegate{
+extension HomeDetailArchiveViewController: CommentTextFieldDelegate {
     
     func commentTextFieldDidUplaod(_ textfield: HomeDetailArchiveCommentTextField,
                                    text: String) {

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeGuideViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeGuideViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HomeGuideViewController : BaseViewController{
+final class HomeGuideViewController : BaseViewController {
     
     //MARK: - Properties
     
@@ -78,12 +78,12 @@ final class HomeGuideViewController : BaseViewController{
     
     //MARK: - Custom Method
     
-    private func setDelegate(){
+    private func setDelegate() {
         cardCollectionView.delegate = self
         cardCollectionView.dataSource = self
     }
     
-    private func registerCell(){
+    private func registerCell() {
         cardCollectionView.register(
             HomeGuideCollectionViewCell.self,
             forCellWithReuseIdentifier: HomeGuideCollectionViewCell.cellIdentifier)
@@ -94,11 +94,11 @@ final class HomeGuideViewController : BaseViewController{
         
     }
     
-    private func setUI(){
+    private func setUI() {
         
     }
     
-    private func setLayout(){
+    private func setLayout() {
         view.addSubviews(cardCollectionView,progressView)
         progressView.addSubview(progressTintView)
         
@@ -121,7 +121,7 @@ final class HomeGuideViewController : BaseViewController{
         
     }
     
-    private func animateTintView(_ direction: Const.ScrollDirection){
+    private func animateTintView(_ direction: Const.ScrollDirection) {
       
         var insetX: CGFloat = 0
         
@@ -139,7 +139,7 @@ final class HomeGuideViewController : BaseViewController{
     
     //MARK: - Action Method
     
-    @objc private func backButtonDidTap(){
+    @objc private func backButtonDidTap() {
         print("backButtonDidTap")
         navigationController?.popViewController(animated: true)
     }
@@ -147,7 +147,7 @@ final class HomeGuideViewController : BaseViewController{
 
 //MARK: - UICollectionView DataSource
 
-extension HomeGuideViewController: UICollectionViewDataSource{
+extension HomeGuideViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         2
@@ -155,7 +155,7 @@ extension HomeGuideViewController: UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        switch indexPath.item{
+        switch indexPath.item {
         case 0 :
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeGuideCollectionViewCell.cellIdentifier, for: indexPath) as? HomeGuideCollectionViewCell else { return UICollectionViewCell() }
 
@@ -171,7 +171,7 @@ extension HomeGuideViewController: UICollectionViewDataSource{
 
 //MARK: - UICollectionViewDelegateFlowLayout
 
-extension HomeGuideViewController: UICollectionViewDelegateFlowLayout{
+extension HomeGuideViewController: UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
@@ -186,7 +186,7 @@ extension HomeGuideViewController: UICollectionViewDelegateFlowLayout{
 
 //MARK: - UIScrollViewDelegate
 
-extension HomeGuideViewController{
+extension HomeGuideViewController {
     
     func scrollViewWillEndDragging( _ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
             
@@ -196,7 +196,7 @@ extension HomeGuideViewController{
         
         targetContentOffset.pointee = CGPoint(x: index * cellWidth - scrollView.contentInset.left, y: scrollView.contentInset.top)
       
-        switch index{
+        switch index {
         case 0:
             animateTintView(.right)
         case 1:
@@ -207,7 +207,7 @@ extension HomeGuideViewController{
       }
 }
 
-extension HomeGuideViewController: HomeMissionCardDelegate{
+extension HomeGuideViewController: HomeMissionCardDelegate {
     func nextButtonDidTap(_ text: String) {
         print("\(text) 받았어요")
         let recordRegisterViewController = RecordRegisterViewController()

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -59,7 +59,6 @@ final class HomeViewController : BaseViewController{
         hierarchy()
         layout()
         
-        autoSelectPetCollectionView()
         requestMissionAPI()
         requestTotalPetAPI()
     }
@@ -276,14 +275,15 @@ final class HomeViewController : BaseViewController{
         archiveListCollectionView.performBatchUpdates(nil, completion: nil)
     }
     
-    private func autoSelectPetCollectionView(){
-        if petData.count != 0 {
-            petCollectionView.selectItem(at:IndexPath(item: 0, section: 0),
-                                         animated: false,
-                                         scrollPosition: .centeredHorizontally)
-            petCollectionView.performBatchUpdates(nil)
-            requestTotalArchiveAPI(petID: petData[0].id)
-        }
+    func selectPetCollectionView(petID: Int){
+        let selectPetArray = petData.filter { $0.id == petID }
+        guard let index = selectPetArray.first?.id else { return }
+    
+        petCollectionView.selectItem(at:IndexPath(item: index, section: 0),
+                                     animated: false,
+                                     scrollPosition: .centeredHorizontally)
+        petCollectionView.performBatchUpdates(nil)
+        requestTotalArchiveAPI(petID: petData[index].id)
     }
     
     private func configIndicatorViewBarWidth(_ scrollView: UIScrollView){
@@ -305,21 +305,22 @@ final class HomeViewController : BaseViewController{
         }
     }
 
-    func requestTotalPetAPI(){
+    private func requestTotalPetAPI(){
         HomeAPI.shared.getTotalPet(familyID: User.familyID) { result in
             
             guard let result = self.validateResult(result) as? [HomePetResult] else { return }
             
             self.petData = result
+            guard let id = self.petData.first?.id else { return }
             
             DispatchQueue.main.async {
-                self.autoSelectPetCollectionView()
+                self.selectPetCollectionView(petID: id)
             }
             
         }
     }
     
-    private func requestTotalArchiveAPI(petID: Int){
+    public func requestTotalArchiveAPI(petID: Int){
         HomeAPI.shared.getTotalArchive(petID: String(petID)) { result in
             
             guard let result = self.validateResult(result) as? [HomeArchiveResult] else { return }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -22,96 +22,34 @@ final class HomeViewController : BaseViewController{
     
     //MARK: - UI Components
     
-    private let missionView : UIView = {
-        let view = UIView()
-        return view
-    }()
+    private let missionView = UIView()
+    private let missionWordLabel = UILabel()
+    private let missionLabel = UILabel()
+    private let noticeButton = UIButton()
     
-    private let missionWordLabel : UILabel = {
-        let label = UILabel()
-        label.text = "미션"
-        label.font = .zoocSubhead1
-        label.textColor = .zoocMainGreen
-        return label
-    }()
+    private let petCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+                                                    
+    private let listButton = UIButton()
+    private let gridButton = UIButton()
     
-    private let missionLabel : UILabel = {
-        let label = UILabel()
-        label.text = "포미와 사진을 찍어보세요"
-        label.font = .zoocBody3
-        label.textColor = .zoocGray3
-        return label
-    }()
-    
-    private lazy var noticeButton : UIButton = {
-        let button = UIButton()
-        button.setImage(Image.ring, for: .normal)
-        button.contentMode = .scaleAspectFit
-        button.addTarget(self, action: #selector(noticeButtonDidTap), for: .touchUpInside)
-        return button
-    }()
-    
-    private let petCollectionView : UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.allowsMultipleSelection = false
-        
-        return collectionView
-    }()
-    
-    private lazy var listButton : UIButton = {
-        let button = UIButton()
-        button.isSelected = true
-        button.tintColor = .systemPink
-        button.setImage(Image.list, for: .normal)
-        button.setImage(Image.listFill, for: .selected)
-        button.addTarget(self, action: #selector(listButtonDidTap), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var gridButton : UIButton = {
-        let button = UIButton()
-        button.setImage(Image.grid, for: .normal)
-        button.setImage(Image.gridFill, for: .selected)
-        button.addTarget(self, action: #selector(galleryButtonDidTap), for: .touchUpInside)
-        return button
-    }()
-    
-    private let archiveListCollectionView : UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
-        collectionView.showsHorizontalScrollIndicator = false
-        return collectionView
-    }()
-    
-    private let archiveGridCollectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .vertical
-        
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .clear
-        return collectionView
-    }()
+    private let archiveListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    private let archiveGridCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
     
     private let archiveBottomView = UIView()
-    private lazy var archiveIndicatorView = HomeArchiveIndicatorView()
+    private let archiveIndicatorView = HomeArchiveIndicatorView()
     
     //MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUI()
-        setLayout()
         register()
         gesture()
+        
+        style()
+        hierarchy()
+        layout()
+        
         autoSelectPetCollectionView()
         updateAPI()
     }
@@ -133,17 +71,83 @@ final class HomeViewController : BaseViewController{
         archiveGridCollectionView.register(HomeArchiveGridCollectionViewCell.self, forCellWithReuseIdentifier: HomeArchiveGridCollectionViewCell.cellIdentifier)
     }
     
-    private func setUI(){
-        archiveListCollectionView.isHidden = false
-        archiveGridCollectionView.isHidden = true
-    }
-    
     private func gesture(){
+        noticeButton.addTarget(self,
+                               action: #selector(noticeButtonDidTap),
+                               for: .touchUpInside)
+        listButton.addTarget(self,
+                             action: #selector(listButtonDidTap),
+                             for: .touchUpInside)
+        
+        gridButton.addTarget(self,
+                             action: #selector(galleryButtonDidTap),
+                             for: .touchUpInside)
+        
         archiveBottomView.addGestureRecognizer(UITapGestureRecognizer(target: self,
                                                                       action: #selector(bottomViewDidTap)))
     }
     
-    private func setLayout(){
+    private func style(){
+        
+        missionWordLabel.do {
+            $0.text = "미션"
+            $0.font = .zoocSubhead1
+            $0.textColor = .zoocMainGreen
+        }
+        
+        missionLabel.do {
+            $0.font = .zoocBody3
+            $0.textColor = .zoocGray3
+        }
+        
+        noticeButton.do {
+            $0.setImage(Image.ring, for: .normal)
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        petCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            $0.collectionViewLayout = layout
+            
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        listButton.do {
+            $0.isSelected = true
+            $0.tintColor = .systemPink
+            $0.setImage(Image.list, for: .normal)
+            $0.setImage(Image.listFill, for: .selected)
+        }
+        
+        gridButton.do {
+            $0.setImage(Image.grid, for: .normal)
+            $0.setImage(Image.gridFill, for: .selected)
+        }
+        
+        archiveListCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            $0.collectionViewLayout = layout
+            
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        archiveGridCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .vertical
+            $0.collectionViewLayout = layout
+            
+            $0.isHidden = true
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+    }
+   
+    
+    private func hierarchy(){
         
         view.addSubviews(
             missionView,
@@ -162,9 +166,11 @@ final class HomeViewController : BaseViewController{
         )
         
         archiveBottomView.addSubview(archiveIndicatorView)
+    }
+    
+    private func layout(){
         
         //MARK: rootView
-        
         missionView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
@@ -207,7 +213,6 @@ final class HomeViewController : BaseViewController{
         }
         
         //MARK: missionView
-        
         missionWordLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(30)
             $0.centerY.equalToSuperview()
@@ -266,7 +271,7 @@ final class HomeViewController : BaseViewController{
                                          animated: false,
                                          scrollPosition: .centeredHorizontally)
             petCollectionView.performBatchUpdates(nil)
-            getTotalArchive(petID: petData[0].id)
+            getTotalArchiveAPI(petID: petData[0].id)
             
             updateIndicatorView(self.archiveListCollectionView)
         }
@@ -298,7 +303,7 @@ final class HomeViewController : BaseViewController{
         }
     }
     
-    private func getTotalArchive(petID: Int){
+    private func getTotalArchiveAPI(petID: Int){
         HomeAPI.shared.getTotalArchive(petID: String(petID)) { result in
             guard let result = self.validateResult(result) as? [HomeArchiveResult] else { return }
             self.archiveData = result
@@ -431,7 +436,7 @@ extension HomeViewController{
     {
         if collectionView == petCollectionView{
             collectionView.performBatchUpdates(nil)
-            getTotalArchive(petID: petData[indexPath.row].id )
+            getTotalArchiveAPI(petID: petData[indexPath.row].id )
             
         }
         

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -14,49 +14,32 @@ final class HomeViewController : BaseViewController{
     
     //MARK: - Properties
     
-    private var petMockData: [HomePetModel] = HomePetModel.mockData
-    private var archiveMockData: [HomeArchiveModel] = HomeArchiveModel.mockData
-    
     private var petData: [HomePetResult] = [] {
         didSet{
-            petCollectionView.reloadData()
+            rootView.petCollectionView.reloadData()
         }
     }
     private var archiveData: [HomeArchiveResult] = []{
         didSet{
-            archiveListCollectionView.reloadData()
-            archiveGridCollectionView.reloadData()
+            rootView.archiveListCollectionView.reloadData()
+            rootView.archiveGridCollectionView.reloadData()
         }
     }
-    
     //MARK: - UI Components
     
-    private let missionView = UIView()
-    private let missionWordLabel = UILabel()
-    private let missionLabel = UILabel()
-    private let noticeButton = UIButton()
-    
-    private let petCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
-    private let listButton = UIButton()
-    private let gridButton = UIButton()
-    
-    private let archiveListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
-    private let archiveGridCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
-    
-    private let archiveBottomView = UIView()
-    private let archiveIndicatorView = HomeArchiveIndicatorView()
+    private let rootView = HomeView()
     
     //MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = rootView
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         register()
         gesture()
-        
-        style()
-        hierarchy()
-        layout()
         
         requestMissionAPI()
         requestTotalPetAPI()
@@ -65,190 +48,43 @@ final class HomeViewController : BaseViewController{
     //MARK: - Custom Method
     
     private func register(){
-        petCollectionView.delegate = self
-        petCollectionView.dataSource = self
+        rootView.petCollectionView.delegate = self
+        rootView.petCollectionView.dataSource = self
         
-        archiveListCollectionView.delegate = self
-        archiveListCollectionView.dataSource = self
-        archiveGridCollectionView.delegate = self
-        archiveGridCollectionView.dataSource = self
+        rootView.archiveListCollectionView.delegate = self
+        rootView.archiveListCollectionView.dataSource = self
+        rootView.archiveGridCollectionView.delegate = self
+        rootView.archiveGridCollectionView.dataSource = self
         
-        petCollectionView.register(HomePetCollectionViewCell.self,
-                                   forCellWithReuseIdentifier:HomePetCollectionViewCell.cellIdentifier)
+        rootView.petCollectionView.register(HomePetCollectionViewCell.self,
+                                            forCellWithReuseIdentifier:HomePetCollectionViewCell.cellIdentifier)
         
-        archiveListCollectionView.register(HomeArchiveListCollectionViewCell.self,
-                                           forCellWithReuseIdentifier: HomeArchiveListCollectionViewCell.cellIdentifier)
+        rootView.archiveListCollectionView.register(HomeArchiveListCollectionViewCell.self,
+                                                    forCellWithReuseIdentifier: HomeArchiveListCollectionViewCell.cellIdentifier)
         
-        archiveGridCollectionView.register(HomeArchiveGridCollectionViewCell.self,
+        rootView.archiveGridCollectionView.register(HomeArchiveGridCollectionViewCell.self,
                                            forCellWithReuseIdentifier: HomeArchiveGridCollectionViewCell.cellIdentifier)
     }
     
     private func gesture(){
-        noticeButton.addTarget(self,
+        rootView.noticeButton.addTarget(self,
                                action: #selector(noticeButtonDidTap),
                                for: .touchUpInside)
-        listButton.addTarget(self,
+        rootView.listButton.addTarget(self,
                              action: #selector(listButtonDidTap),
                              for: .touchUpInside)
         
-        gridButton.addTarget(self,
+        rootView.gridButton.addTarget(self,
                              action: #selector(galleryButtonDidTap),
                              for: .touchUpInside)
         
-        archiveBottomView.addGestureRecognizer(UITapGestureRecognizer(target: self,
+        rootView.archiveBottomView.addGestureRecognizer(UITapGestureRecognizer(target: self,
                                                                       action: #selector(bottomViewDidTap)))
     }
     
-    private func style(){
-        
-        missionWordLabel.do {
-            $0.text = "미션"
-            $0.font = .zoocSubhead1
-            $0.textColor = .zoocMainGreen
-        }
-        
-        missionLabel.do {
-            $0.font = .zoocBody3
-            $0.textColor = .zoocGray3
-        }
-        
-        noticeButton.do {
-            $0.setImage(Image.ring, for: .normal)
-            $0.contentMode = .scaleAspectFit
-        }
-        
-        petCollectionView.do {
-            let layout = UICollectionViewFlowLayout()
-            layout.scrollDirection = .horizontal
-            $0.collectionViewLayout = layout
-            
-            $0.backgroundColor = .clear
-            $0.showsHorizontalScrollIndicator = false
-        }
-        
-        listButton.do {
-            $0.isSelected = true
-            $0.tintColor = .systemPink
-            $0.setImage(Image.list, for: .normal)
-            $0.setImage(Image.listFill, for: .selected)
-        }
-        
-        gridButton.do {
-            $0.setImage(Image.grid, for: .normal)
-            $0.setImage(Image.gridFill, for: .selected)
-        }
-        
-        archiveListCollectionView.do {
-            let layout = UICollectionViewFlowLayout()
-            layout.scrollDirection = .horizontal
-            $0.collectionViewLayout = layout
-            
-            $0.backgroundColor = .clear
-            $0.showsHorizontalScrollIndicator = false
-        }
-        
-        archiveGridCollectionView.do {
-            let layout = UICollectionViewFlowLayout()
-            layout.scrollDirection = .vertical
-            $0.collectionViewLayout = layout
-            
-            $0.isHidden = true
-            $0.backgroundColor = .clear
-            $0.showsHorizontalScrollIndicator = false
-        }
-    }
-   
-    
-    private func hierarchy(){
-        
-        view.addSubviews(missionView,
-                         petCollectionView,
-                         listButton,
-                         gridButton,
-                         archiveBottomView,
-                         archiveListCollectionView,
-                         archiveGridCollectionView)
-                          
-        
-        missionView.addSubviews(missionWordLabel,
-                                missionLabel,
-                                noticeButton)
-                                
-        
-        archiveBottomView.addSubview(archiveIndicatorView)
-    }
-    
-    private func layout(){
-        
-        //MARK: rootView
-        missionView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(50)
-        }
-        
-        listButton.snp.makeConstraints {
-            $0.centerY.equalTo(petCollectionView)
-            $0.trailing.equalTo(gridButton.snp.leading)
-            $0.height.width.equalTo(36)
-        }
-        
-        gridButton.snp.makeConstraints {
-            $0.centerY.equalTo(petCollectionView)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.height.width.equalTo(36)
-        }
-        
-        petCollectionView.snp.makeConstraints {
-            $0.top.equalTo(missionView.snp.bottom).offset(20)
-            $0.leading.equalToSuperview().offset(30)
-            $0.trailing.equalTo(listButton.snp.leading)
-            $0.height.equalTo(40)
-        }
-        
-        archiveListCollectionView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(petCollectionView.snp.bottom).offset(29)
-            $0.height.equalTo(438)
-        }
-        
-        archiveGridCollectionView.snp.makeConstraints {
-            $0.edges.equalTo(archiveListCollectionView)
-        }
-        
-        archiveBottomView.snp.makeConstraints {
-            $0.top.equalTo(archiveListCollectionView.snp.bottom)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-        //MARK: missionView
-        missionWordLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(30)
-            $0.centerY.equalToSuperview()
-        }
-        
-        missionLabel.snp.makeConstraints {
-            $0.leading.equalTo(missionWordLabel.snp.trailing).offset(10)
-            $0.centerY.equalToSuperview()
-        }
-        
-        noticeButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
-            $0.height.width.equalTo(42)
-        }
-        
-        //MARK: archiveBottomView
-        archiveIndicatorView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(72)
-            $0.height.equalTo(4)
-        }
-    }
     
     private func pushToDetailViewController(recordID: String){
-        guard let index = petCollectionView.indexPathsForSelectedItems?[0].item else {
+        guard let index = rootView.petCollectionView.indexPathsForSelectedItems?[0].item else {
             presentBottomAlert("선택된 펫이 없습니다.")
             return
         }
@@ -269,9 +105,9 @@ final class HomeViewController : BaseViewController{
     }
     
     private func deselectAllOfListArchiveCollectionViewCell(){
-        archiveListCollectionView.indexPathsForSelectedItems?
-            .forEach { archiveListCollectionView.deselectItem(at: $0, animated: false) }
-        archiveListCollectionView.performBatchUpdates(nil, completion: nil)
+        rootView.archiveListCollectionView.indexPathsForSelectedItems?
+            .forEach { rootView.archiveListCollectionView.deselectItem(at: $0, animated: false) }
+        rootView.archiveListCollectionView.performBatchUpdates(nil, completion: nil)
     }
     
     func selectPetCollectionView(petID: Int){
@@ -283,10 +119,10 @@ final class HomeViewController : BaseViewController{
         
         guard index < petData.count else { return }
     
-        petCollectionView.selectItem(at:IndexPath(item: index, section: 0),
+        rootView.petCollectionView.selectItem(at:IndexPath(item: index, section: 0),
                                      animated: false,
                                      scrollPosition: .centeredHorizontally)
-        petCollectionView.performBatchUpdates(nil)
+        rootView.petCollectionView.performBatchUpdates(nil)
         requestTotalArchiveAPI(petID: petData[index].id)
     }
     
@@ -294,8 +130,8 @@ final class HomeViewController : BaseViewController{
         UIView.animate(withDuration: 0.5) {
             let allWidth = scrollView.contentSize.width + scrollView.contentInset.left + scrollView.contentInset.right
             let showingWidth = scrollView.bounds.width
-            self.archiveIndicatorView.widthRatio = showingWidth / allWidth
-            self.archiveIndicatorView.layoutIfNeeded()
+            self.rootView.archiveIndicatorView.widthRatio = showingWidth / allWidth
+            self.rootView.archiveIndicatorView.layoutIfNeeded()
         }
     }
     
@@ -306,7 +142,7 @@ final class HomeViewController : BaseViewController{
             
             guard let result = self.validateResult(result) as? [HomeMissionResult] else { return }
             
-            self.missionLabel.text = result[0].missionContent //TODO: 미션용 API 필요
+            self.rootView.missionLabel.text = result[0].missionContent //TODO: 미션용 API 필요
         }
     }
 
@@ -333,7 +169,7 @@ final class HomeViewController : BaseViewController{
             self.archiveData = result
             
             DispatchQueue.main.async {
-                self.configIndicatorBarWidth(self.archiveListCollectionView)
+                self.configIndicatorBarWidth(self.rootView.archiveListCollectionView)
             }
         }
     }
@@ -348,14 +184,14 @@ final class HomeViewController : BaseViewController{
     
     @objc
     private func listButtonDidTap(){
-        archiveListCollectionView.isHidden = false
-        archiveGridCollectionView.isHidden = true
-        archiveBottomView.isHidden = false
-        listButton.isSelected = true
-        gridButton.isSelected = false
+        rootView.archiveListCollectionView.isHidden = false
+        rootView.archiveGridCollectionView.isHidden = true
+        rootView.archiveBottomView.isHidden = false
+        rootView.listButton.isSelected = true
+        rootView.gridButton.isSelected = false
         
-        archiveListCollectionView.snp.remakeConstraints {
-            $0.top.equalTo(petCollectionView.snp.bottom).offset(29)
+        rootView.archiveListCollectionView.snp.remakeConstraints {
+            $0.top.equalTo(rootView.petCollectionView.snp.bottom).offset(29)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(438)
         }
@@ -363,15 +199,15 @@ final class HomeViewController : BaseViewController{
     
     @objc
     private func galleryButtonDidTap(){
-        archiveListCollectionView.isHidden = true
-        archiveGridCollectionView.isHidden = false
-        archiveBottomView.isHidden = true
+        rootView.archiveListCollectionView.isHidden = true
+        rootView.archiveGridCollectionView.isHidden = false
+        rootView.archiveBottomView.isHidden = true
         
-        listButton.isSelected = false
-        gridButton.isSelected = true
+        rootView.listButton.isSelected = false
+        rootView.gridButton.isSelected = true
         
-        archiveListCollectionView.snp.remakeConstraints {
-            $0.top.equalTo(petCollectionView.snp.bottom).offset(29)
+        rootView.archiveListCollectionView.snp.remakeConstraints {
+            $0.top.equalTo(rootView.petCollectionView.snp.bottom).offset(29)
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
@@ -390,15 +226,15 @@ final class HomeViewController : BaseViewController{
 extension HomeViewController: UICollectionViewDataSource{
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             return petData.count
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             return archiveData.count
         }
         
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             return archiveData.count
         }
         
@@ -407,7 +243,7 @@ extension HomeViewController: UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomePetCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomePetCollectionViewCell else { return UICollectionViewCell() }
             
@@ -415,7 +251,7 @@ extension HomeViewController: UICollectionViewDataSource{
             return cell
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeArchiveListCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomeArchiveListCollectionViewCell else { return UICollectionViewCell() }
             
@@ -424,7 +260,7 @@ extension HomeViewController: UICollectionViewDataSource{
             return cell
         }
         
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeArchiveGridCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomeArchiveGridCollectionViewCell else { return UICollectionViewCell() }
             
@@ -444,7 +280,7 @@ extension HomeViewController{
     func collectionView(_ collectionView: UICollectionView,
                         shouldSelectItemAt indexPath: IndexPath) -> Bool
     {
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             guard let cell = collectionView.cellForItem(at: indexPath) as? HomeArchiveListCollectionViewCell else { return false }
             
             switch cell.viewType{
@@ -463,17 +299,17 @@ extension HomeViewController{
     func collectionView(_ collectionView: UICollectionView,
                         didSelectItemAt indexPath: IndexPath)
     {
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             collectionView.performBatchUpdates(nil)
             requestTotalArchiveAPI(petID: petData[indexPath.item].id )
             
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             collectionView.performBatchUpdates(nil)
         }
         
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             let id = String(archiveData[indexPath.item].record.id)
             pushToDetailViewController(recordID: id)
         }
@@ -483,11 +319,11 @@ extension HomeViewController{
     func collectionView(_ collectionView: UICollectionView,
                         didDeselectItemAt indexPath: IndexPath)
     {
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             collectionView.performBatchUpdates(nil)
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             collectionView.performBatchUpdates(nil)
         }
     }
@@ -500,7 +336,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize
     {
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             switch collectionView.indexPathsForSelectedItems?.first {
             case .some(indexPath):
                 guard let cell = collectionView.cellForItem(at: indexPath) as? HomePetCollectionViewCell else { return .zero}
@@ -511,7 +347,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
             }
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             switch collectionView.indexPathsForSelectedItems?.first {
             case .some(indexPath):
                 return CGSize(width: 195, height: 436)
@@ -520,7 +356,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
             }
         }
         
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             return CGSize(width: 100, height: 100)
         }
         
@@ -531,14 +367,14 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
                         layout collectionViewLayout: UICollectionViewLayout,
                         minimumLineSpacingForSectionAt section: Int) -> CGFloat
     {
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             return 4
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             return 11
         }
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             return 10
         }
         
@@ -550,15 +386,15 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets
     {
-        if collectionView == petCollectionView{
+        if collectionView == rootView.petCollectionView{
             return .zero
         }
         
-        if collectionView == archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView{
             return UIEdgeInsets(top: 0, left: 30, bottom: 0, right: 30)
         }
         
-        if collectionView == archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView{
             return UIEdgeInsets(top: 0, left: 30, bottom: 30, right: 30)
         }
         
@@ -572,13 +408,13 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
 extension HomeViewController{
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView == archiveListCollectionView{
+        if scrollView == rootView.archiveListCollectionView{
             
             let scroll = scrollView.contentOffset.x + scrollView.contentInset.left
             let width = scrollView.contentSize.width + scrollView.contentInset.left + scrollView.contentInset.right
             let scrollRatio = scroll / width
             
-            self.archiveIndicatorView.leftOffsetRatio = scrollRatio
+            self.rootView.archiveIndicatorView.leftOffsetRatio = scrollRatio
         }
     }
 }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -37,7 +37,6 @@ final class HomeViewController : BaseViewController{
     private let noticeButton = UIButton()
     
     private let petCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
-                                                    
     private let listButton = UIButton()
     private let gridButton = UIButton()
     
@@ -276,8 +275,13 @@ final class HomeViewController : BaseViewController{
     }
     
     func selectPetCollectionView(petID: Int){
-        let selectPetArray = petData.filter { $0.id == petID }
-        guard let index = selectPetArray.first?.id else { return }
+        var index = 0
+        for pet in petData{
+            if pet.id == petID{ break }
+            index += 1
+        }
+        
+        guard index < petData.count else { return }
     
         petCollectionView.selectItem(at:IndexPath(item: index, section: 0),
                                      animated: false,
@@ -286,12 +290,13 @@ final class HomeViewController : BaseViewController{
         requestTotalArchiveAPI(petID: petData[index].id)
     }
     
-    private func configIndicatorViewBarWidth(_ scrollView: UIScrollView){
-        let allWidth = scrollView.contentSize.width + scrollView.contentInset.left + scrollView.contentInset.right
-        let showingWidth = scrollView.bounds.width
-        
-        self.archiveIndicatorView.widthRatio = showingWidth / allWidth
-        self.archiveIndicatorView.layoutIfNeeded()
+    private func configIndicatorBarWidth(_ scrollView: UIScrollView){
+        UIView.animate(withDuration: 0.5) {
+            let allWidth = scrollView.contentSize.width + scrollView.contentInset.left + scrollView.contentInset.right
+            let showingWidth = scrollView.bounds.width
+            self.archiveIndicatorView.widthRatio = showingWidth / allWidth
+            self.archiveIndicatorView.layoutIfNeeded()
+        }
     }
     
     //MARK: - Network
@@ -328,7 +333,7 @@ final class HomeViewController : BaseViewController{
             self.archiveData = result
             
             DispatchQueue.main.async {
-                self.configIndicatorViewBarWidth(self.archiveListCollectionView)
+                self.configIndicatorBarWidth(self.archiveListCollectionView)
             }
         }
     }

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HomeViewController : BaseViewController{
+final class HomeViewController : BaseViewController {
     
     //MARK: - Properties
     
@@ -47,7 +47,7 @@ final class HomeViewController : BaseViewController{
     
     //MARK: - Custom Method
     
-    private func register(){
+    private func register() {
         rootView.petCollectionView.delegate = self
         rootView.petCollectionView.dataSource = self
         
@@ -66,7 +66,7 @@ final class HomeViewController : BaseViewController{
                                            forCellWithReuseIdentifier: HomeArchiveGridCollectionViewCell.cellIdentifier)
     }
     
-    private func gesture(){
+    private func gesture() {
         rootView.noticeButton.addTarget(self,
                                action: #selector(noticeButtonDidTap),
                                for: .touchUpInside)
@@ -83,7 +83,7 @@ final class HomeViewController : BaseViewController{
     }
     
     
-    private func pushToDetailViewController(recordID: String){
+    private func pushToDetailViewController(recordID: String) {
         guard let index = rootView.petCollectionView.indexPathsForSelectedItems?[0].item else {
             presentBottomAlert("선택된 펫이 없습니다.")
             return
@@ -98,19 +98,19 @@ final class HomeViewController : BaseViewController{
         navigationController?.pushViewController(detailVC, animated: true)
     }
     
-    private func pushToHomeAlarmViewController(){
+    private func pushToHomeAlarmViewController() {
         let noticeVC = HomeNoticeViewController()
         noticeVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(noticeVC, animated: true)
     }
     
-    private func deselectAllOfListArchiveCollectionViewCell(){
+    private func deselectAllOfListArchiveCollectionViewCell() {
         rootView.archiveListCollectionView.indexPathsForSelectedItems?
             .forEach { rootView.archiveListCollectionView.deselectItem(at: $0, animated: false) }
         rootView.archiveListCollectionView.performBatchUpdates(nil, completion: nil)
     }
     
-    func selectPetCollectionView(petID: Int){
+    func selectPetCollectionView(petID: Int) {
         var index = 0
         for pet in petData{
             if pet.id == petID{ break }
@@ -126,7 +126,7 @@ final class HomeViewController : BaseViewController{
         requestTotalArchiveAPI(petID: petData[index].id)
     }
     
-    private func configIndicatorBarWidth(_ scrollView: UIScrollView){
+    private func configIndicatorBarWidth(_ scrollView: UIScrollView) {
         UIView.animate(withDuration: 0.5) {
             let allWidth = scrollView.contentSize.width + scrollView.contentInset.left + scrollView.contentInset.right
             let showingWidth = scrollView.bounds.width
@@ -137,7 +137,7 @@ final class HomeViewController : BaseViewController{
     
     //MARK: - Network
     
-    private func requestMissionAPI(){
+    private func requestMissionAPI() {
         HomeAPI.shared.getMission(familyID: User.familyID) { result in
             
             guard let result = self.validateResult(result) as? [HomeMissionResult] else { return }
@@ -146,7 +146,7 @@ final class HomeViewController : BaseViewController{
         }
     }
 
-    private func requestTotalPetAPI(){
+    private func requestTotalPetAPI() {
         HomeAPI.shared.getTotalPet(familyID: User.familyID) { result in
             
             guard let result = self.validateResult(result) as? [HomePetResult] else { return }
@@ -161,7 +161,7 @@ final class HomeViewController : BaseViewController{
         }
     }
     
-    public func requestTotalArchiveAPI(petID: Int){
+    public func requestTotalArchiveAPI(petID: Int) {
         HomeAPI.shared.getTotalArchive(petID: String(petID)) { result in
             
             guard let result = self.validateResult(result) as? [HomeArchiveResult] else { return }
@@ -178,12 +178,12 @@ final class HomeViewController : BaseViewController{
     //MARK: - Action Method
     
     @objc
-    private func noticeButtonDidTap(){
+    private func noticeButtonDidTap() {
         pushToHomeAlarmViewController()
     }
     
     @objc
-    private func listButtonDidTap(){
+    private func listButtonDidTap() {
         rootView.archiveListCollectionView.isHidden = false
         rootView.archiveGridCollectionView.isHidden = true
         rootView.archiveBottomView.isHidden = false
@@ -198,7 +198,7 @@ final class HomeViewController : BaseViewController{
     }
     
     @objc
-    private func galleryButtonDidTap(){
+    private func galleryButtonDidTap() {
         rootView.archiveListCollectionView.isHidden = true
         rootView.archiveGridCollectionView.isHidden = false
         rootView.archiveBottomView.isHidden = true
@@ -214,7 +214,7 @@ final class HomeViewController : BaseViewController{
     }
     
     @objc
-    private func bottomViewDidTap(){
+    private func bottomViewDidTap() {
         deselectAllOfListArchiveCollectionViewCell()
     }
     
@@ -223,18 +223,18 @@ final class HomeViewController : BaseViewController{
 
 //MARK: - UICollectionViewDataSource
 
-extension HomeViewController: UICollectionViewDataSource{
+extension HomeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             return petData.count
         }
         
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             return archiveData.count
         }
         
-        if collectionView == rootView.archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView {
             return archiveData.count
         }
         
@@ -243,7 +243,7 @@ extension HomeViewController: UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomePetCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomePetCollectionViewCell else { return UICollectionViewCell() }
             
@@ -251,7 +251,7 @@ extension HomeViewController: UICollectionViewDataSource{
             return cell
         }
         
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeArchiveListCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomeArchiveListCollectionViewCell else { return UICollectionViewCell() }
             
@@ -260,7 +260,7 @@ extension HomeViewController: UICollectionViewDataSource{
             return cell
         }
         
-        if collectionView == rootView.archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HomeArchiveGridCollectionViewCell.cellIdentifier,
                                                                 for: indexPath) as?  HomeArchiveGridCollectionViewCell else { return UICollectionViewCell() }
             
@@ -275,15 +275,15 @@ extension HomeViewController: UICollectionViewDataSource{
 
 //MARK: - UICollectionViewDelegate
 
-extension HomeViewController{
+extension HomeViewController {
     
     func collectionView(_ collectionView: UICollectionView,
                         shouldSelectItemAt indexPath: IndexPath) -> Bool
     {
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             guard let cell = collectionView.cellForItem(at: indexPath) as? HomeArchiveListCollectionViewCell else { return false }
             
-            switch cell.viewType{
+            switch cell.viewType {
             case .folded:
                 return true
             case .expanded:
@@ -299,17 +299,17 @@ extension HomeViewController{
     func collectionView(_ collectionView: UICollectionView,
                         didSelectItemAt indexPath: IndexPath)
     {
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             collectionView.performBatchUpdates(nil)
             requestTotalArchiveAPI(petID: petData[indexPath.item].id )
             
         }
         
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             collectionView.performBatchUpdates(nil)
         }
         
-        if collectionView == rootView.archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView {
             let id = String(archiveData[indexPath.item].record.id)
             pushToDetailViewController(recordID: id)
         }
@@ -319,24 +319,25 @@ extension HomeViewController{
     func collectionView(_ collectionView: UICollectionView,
                         didDeselectItemAt indexPath: IndexPath)
     {
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
+            collectionView.performBatchUpdates(nil)
+        }
+         
+        if collectionView == rootView.archiveListCollectionView {
             collectionView.performBatchUpdates(nil)
         }
         
-        if collectionView == rootView.archiveListCollectionView{
-            collectionView.performBatchUpdates(nil)
-        }
     }
 }
 
 //MARK: - UICollectionViewDelegateFlowLayout
 
-extension HomeViewController: UICollectionViewDelegateFlowLayout{
+extension HomeViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize
     {
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             switch collectionView.indexPathsForSelectedItems?.first {
             case .some(indexPath):
                 guard let cell = collectionView.cellForItem(at: indexPath) as? HomePetCollectionViewCell else { return .zero}
@@ -347,7 +348,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
             }
         }
         
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             switch collectionView.indexPathsForSelectedItems?.first {
             case .some(indexPath):
                 return CGSize(width: 195, height: 436)
@@ -356,7 +357,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
             }
         }
         
-        if collectionView == rootView.archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView {
             return CGSize(width: 100, height: 100)
         }
         
@@ -367,14 +368,14 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
                         layout collectionViewLayout: UICollectionViewLayout,
                         minimumLineSpacingForSectionAt section: Int) -> CGFloat
     {
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             return 4
         }
         
-        if collectionView == rootView.archiveListCollectionView{
+        if collectionView == rootView.archiveListCollectionView {
             return 11
         }
-        if collectionView == rootView.archiveGridCollectionView{
+        if collectionView == rootView.archiveGridCollectionView {
             return 10
         }
         
@@ -386,7 +387,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
                         layout collectionViewLayout: UICollectionViewLayout,
                         insetForSectionAt section: Int) -> UIEdgeInsets
     {
-        if collectionView == rootView.petCollectionView{
+        if collectionView == rootView.petCollectionView {
             return .zero
         }
         
@@ -405,7 +406,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout{
 
 //MARK: - ScrollViewDelegate
 
-extension HomeViewController{
+extension HomeViewController {
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == rootView.archiveListCollectionView{

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -250,7 +250,7 @@ final class HomeViewController : BaseViewController{
     }
     
     private func pushToDetailViewController(recordID: String){
-        guard let index = petCollectionView.indexPathsForSelectedItems?[0].row else {
+        guard let index = petCollectionView.indexPathsForSelectedItems?[0].item else {
             presentBottomAlert("선택된 펫이 없습니다.")
             return
         }
@@ -278,7 +278,7 @@ final class HomeViewController : BaseViewController{
     
     private func autoSelectPetCollectionView(){
         if petData.count != 0 {
-            petCollectionView.selectItem(at: IndexPath(row: 0, section: 0),
+            petCollectionView.selectItem(at:IndexPath(item: 0, section: 0),
                                          animated: false,
                                          scrollPosition: .centeredHorizontally)
             petCollectionView.performBatchUpdates(nil)
@@ -459,7 +459,7 @@ extension HomeViewController{
     {
         if collectionView == petCollectionView{
             collectionView.performBatchUpdates(nil)
-            requestTotalArchiveAPI(petID: petData[indexPath.row].id )
+            requestTotalArchiveAPI(petID: petData[indexPath.item].id )
             
         }
         

--- a/ZOOC/ZOOC/Presentation/Home/View/HomeArchiveIndicatorView.swift
+++ b/ZOOC/ZOOC/Presentation/Home/View/HomeArchiveIndicatorView.swift
@@ -63,11 +63,11 @@ final class HomeArchiveIndicatorView : UIView{
     
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         
     }
     
-    private func setLayout(){
+    private func setLayout() {
         self.addSubview(indicatorView)
         indicatorView.addSubview(indicatorTintView)
         

--- a/ZOOC/ZOOC/Presentation/Home/View/HomeDetailArchiveCommentTextField.swift
+++ b/ZOOC/ZOOC/Presentation/Home/View/HomeDetailArchiveCommentTextField.swift
@@ -55,7 +55,7 @@ final class HomeDetailArchiveCommentTextField: UITextField{
     
     //MARK: - Custom Method
     
-    private func setUI(){
+    private func setUI() {
         self.placeholder = "댓글을 입력해보세요"
         self.backgroundColor = .zoocWhite2
         self.layer.borderColor = UIColor.lightGray.cgColor
@@ -64,7 +64,7 @@ final class HomeDetailArchiveCommentTextField: UITextField{
         self.isUserInteractionEnabled = true
     }
     
-    private func setLayout(){
+    private func setLayout() {
         self.addSubview(uploadButton)
         
         uploadButton.snp.makeConstraints {
@@ -74,7 +74,7 @@ final class HomeDetailArchiveCommentTextField: UITextField{
         } 
     }
     
-    private func validateText(_ text: String?) -> String{
+    private func validateText(_ text: String?) -> String {
         print("1 ----- \(text) -----")
         guard let text = text else { return "nil값 입니다."}
         print("2 ----- \(text) -----")
@@ -91,7 +91,7 @@ final class HomeDetailArchiveCommentTextField: UITextField{
     //MARK: - Action Method
     
     @objc
-    private func uploadButtonDidTap(){
+    private func uploadButtonDidTap() {
         validateText(self.text)
         
     }

--- a/ZOOC/ZOOC/Presentation/Home/View/HomeView.swift
+++ b/ZOOC/ZOOC/Presentation/Home/View/HomeView.swift
@@ -1,0 +1,199 @@
+//
+//  HomeView.swift
+//  ZOOC
+//
+//  Created by 장석우 on 2023/01/21.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class HomeView : UIView{
+    
+    //MARK: - Properties
+    
+    //MARK: - UI Components
+    
+    public let missionView = UIView()
+    public let missionWordLabel = UILabel()
+    public let missionLabel = UILabel()
+    public let noticeButton = UIButton()
+    
+    public let petCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    public let listButton = UIButton()
+    public let gridButton = UIButton()
+    
+    public let archiveListCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    public let archiveGridCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
+    
+    public let archiveBottomView = UIView()
+    public let archiveIndicatorView = HomeArchiveIndicatorView()
+    
+    //MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        style()
+        hierarchy()
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    //MARK: - Custom Method
+    
+    
+    private func style(){
+        
+        missionWordLabel.do {
+            $0.text = "미션"
+            $0.font = .zoocSubhead1
+            $0.textColor = .zoocMainGreen
+        }
+        
+        missionLabel.do {
+            $0.font = .zoocBody3
+            $0.textColor = .zoocGray3
+        }
+        
+        noticeButton.do {
+            $0.setImage(Image.ring, for: .normal)
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        petCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            $0.collectionViewLayout = layout
+            
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        listButton.do {
+            $0.isSelected = true
+            $0.tintColor = .systemPink
+            $0.setImage(Image.list, for: .normal)
+            $0.setImage(Image.listFill, for: .selected)
+        }
+        
+        gridButton.do {
+            $0.setImage(Image.grid, for: .normal)
+            $0.setImage(Image.gridFill, for: .selected)
+        }
+        
+        archiveListCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            $0.collectionViewLayout = layout
+            
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+        
+        archiveGridCollectionView.do {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .vertical
+            $0.collectionViewLayout = layout
+            
+            $0.isHidden = true
+            $0.backgroundColor = .clear
+            $0.showsHorizontalScrollIndicator = false
+        }
+    }
+   
+    
+    private func hierarchy(){
+        
+        self.addSubviews(missionView,
+                         petCollectionView,
+                         listButton,
+                         gridButton,
+                         archiveBottomView,
+                         archiveListCollectionView,
+                         archiveGridCollectionView)
+                          
+        
+        missionView.addSubviews(missionWordLabel,
+                                missionLabel,
+                                noticeButton)
+                                
+        
+        archiveBottomView.addSubview(archiveIndicatorView)
+    }
+    
+    private func layout(){
+        
+        //MARK: rootView
+        missionView.snp.makeConstraints {
+            $0.top.equalTo(self.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(50)
+        }
+        
+        listButton.snp.makeConstraints {
+            $0.centerY.equalTo(petCollectionView)
+            $0.trailing.equalTo(gridButton.snp.leading)
+            $0.height.width.equalTo(36)
+        }
+        
+        gridButton.snp.makeConstraints {
+            $0.centerY.equalTo(petCollectionView)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.height.width.equalTo(36)
+        }
+        
+        petCollectionView.snp.makeConstraints {
+            $0.top.equalTo(missionView.snp.bottom).offset(20)
+            $0.leading.equalToSuperview().offset(30)
+            $0.trailing.equalTo(listButton.snp.leading)
+            $0.height.equalTo(40)
+        }
+        
+        archiveListCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalTo(petCollectionView.snp.bottom).offset(29)
+            $0.height.equalTo(438)
+        }
+        
+        archiveGridCollectionView.snp.makeConstraints {
+            $0.edges.equalTo(archiveListCollectionView)
+        }
+        
+        archiveBottomView.snp.makeConstraints {
+            $0.top.equalTo(archiveListCollectionView.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+        }
+        
+        //MARK: missionView
+        missionWordLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(30)
+            $0.centerY.equalToSuperview()
+        }
+        
+        missionLabel.snp.makeConstraints {
+            $0.leading.equalTo(missionWordLabel.snp.trailing).offset(10)
+            $0.centerY.equalToSuperview()
+        }
+        
+        noticeButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.height.width.equalTo(42)
+        }
+        
+        //MARK: archiveBottomView
+        archiveIndicatorView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(72)
+            $0.height.equalTo(4)
+        }
+    }
+    
+}

--- a/ZOOC/ZOOC/Presentation/Home/View/HomeView.swift
+++ b/ZOOC/ZOOC/Presentation/Home/View/HomeView.swift
@@ -48,7 +48,7 @@ final class HomeView : UIView{
     //MARK: - Custom Method
     
     
-    private func style(){
+    private func style() {
         
         missionWordLabel.do {
             $0.text = "미션"
@@ -108,7 +108,7 @@ final class HomeView : UIView{
     }
    
     
-    private func hierarchy(){
+    private func hierarchy() {
         
         self.addSubviews(missionView,
                          petCollectionView,
@@ -127,9 +127,10 @@ final class HomeView : UIView{
         archiveBottomView.addSubview(archiveIndicatorView)
     }
     
-    private func layout(){
+    private func layout() {
         
         //MARK: rootView
+        
         missionView.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
@@ -172,6 +173,7 @@ final class HomeView : UIView{
         }
         
         //MARK: missionView
+        
         missionWordLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(30)
             $0.centerY.equalToSuperview()
@@ -189,6 +191,7 @@ final class HomeView : UIView{
         }
         
         //MARK: archiveBottomView
+        
         archiveIndicatorView.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(72)

--- a/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
@@ -113,8 +113,8 @@ final class RecordCompleteViewController : BaseViewController {
         }
     }
     
-    func dataBind(data: [RecordRegisterModel]){
-        firstPetID = data[0].petID
+    func dataBind(data: [Int]){
+        firstPetID = data.first
     }
     
     //MARK: - Action Method
@@ -123,6 +123,7 @@ final class RecordCompleteViewController : BaseViewController {
     private func goArchiveButtonDidTap() {
         
         guard let tabVC = navigationController?.previousViewController?.presentingViewController as? ZoocTabBarController else { return }
+        
         guard let petID = firstPetID else { return }
         tabVC.homeViewController.selectPetCollectionView(petID: petID)
         

--- a/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
@@ -117,9 +117,8 @@ final class RecordCompleteViewController : BaseViewController {
     @objc
     private func goArchiveButtonDidTap() {
         
-//
         guard let tabVC = navigationController?.previousViewController?.presentingViewController as? ZoocTabBarController else { return }
-        tabVC.homeViewController.updateAPI()
+        tabVC.homeViewController.requestTotalPetAPI()
         
         self.navigationController?.previousViewController?.navigationController?.previousViewController?.dismiss(animated: true)
     }

--- a/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Record/Controller/RecordCompleteViewController.swift
@@ -11,6 +11,10 @@ import SnapKit
 
 final class RecordCompleteViewController : BaseViewController {
     
+    //MARK: - Properties
+    
+    var firstPetID: Int?
+    
     //MARK: - UI Components
     
     private let cardView: UIView = {
@@ -108,9 +112,10 @@ final class RecordCompleteViewController : BaseViewController {
             $0.bottom.equalToSuperview().inset(22)
         }
     }
-
-    //MARK: - Custom Method
-
+    
+    func dataBind(data: [RecordRegisterModel]){
+        firstPetID = data[0].petID
+    }
     
     //MARK: - Action Method
     
@@ -118,7 +123,8 @@ final class RecordCompleteViewController : BaseViewController {
     private func goArchiveButtonDidTap() {
         
         guard let tabVC = navigationController?.previousViewController?.presentingViewController as? ZoocTabBarController else { return }
-        tabVC.homeViewController.requestTotalPetAPI()
+        guard let petID = firstPetID else { return }
+        tabVC.homeViewController.selectPetCollectionView(petID: petID)
         
         self.navigationController?.previousViewController?.navigationController?.previousViewController?.dismiss(animated: true)
     }

--- a/ZOOC/ZOOC/Presentation/Record/Controller/RecordRegisterViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Record/Controller/RecordRegisterViewController.swift
@@ -15,7 +15,6 @@ final class RecordRegisterViewController : BaseViewController{
     // MARK: - Properties
     
     var recordData: RecordModel = RecordModel()
-
     var petList: [RecordRegisterModel] = []
     
     
@@ -312,8 +311,9 @@ final class RecordRegisterViewController : BaseViewController{
     }
     
     private func pushToRecordCompleteViewController() {
-        let recordCompleteViewController = RecordCompleteViewController()
-        self.navigationController?.pushViewController(recordCompleteViewController, animated: true)
+        let recordCompleteVC = RecordCompleteViewController()
+        recordCompleteVC.dataBind(data: petList)
+        self.navigationController?.pushViewController(recordCompleteVC, animated: true)
     }
 }
 

--- a/ZOOC/ZOOC/Presentation/Record/Controller/RecordRegisterViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Record/Controller/RecordRegisterViewController.swift
@@ -16,7 +16,7 @@ final class RecordRegisterViewController : BaseViewController{
     
     var recordData: RecordModel = RecordModel()
     var petList: [RecordRegisterModel] = []
-    
+    var selectedPetIDList: [Int] = []
     
     // MARK: - UI Components
     
@@ -280,24 +280,20 @@ final class RecordRegisterViewController : BaseViewController{
     
     @objc
     private func registerButtonDidTap(){
-        var selectedPetID: [Int] = []
+        
         petList.forEach {
             if $0.isSelected {
-                selectedPetID.append($0.petID)
+                selectedPetIDList.append($0.petID)
             }
         }
         registerButton.isEnabled = false
         registerButton.backgroundColor = .zoocGray1
         
-        RecordAPI.shared.postRecord(
-                                    photo: recordData.image ?? UIImage(),
+        RecordAPI.shared.postRecord(photo: recordData.image ?? UIImage(),
                                     content: recordData.content ?? "",
-                                    pets: selectedPetID)
-        { result in
-                self.pushToRecordCompleteViewController()
+                                    pets: selectedPetIDList) { result in
+            self.pushToRecordCompleteViewController()
         }
-        
-        
     }
     
     private func activateButton(indexPathArray: [IndexPath]?) {
@@ -312,7 +308,7 @@ final class RecordRegisterViewController : BaseViewController{
     
     private func pushToRecordCompleteViewController() {
         let recordCompleteVC = RecordCompleteViewController()
-        recordCompleteVC.dataBind(data: petList)
+        recordCompleteVC.dataBind(data: selectedPetIDList)
         self.navigationController?.pushViewController(recordCompleteVC, animated: true)
     }
 }


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #64

### ✅ 작업한 내용
- UIComponets 선언부 변경
  -  `style()`에서 `do` 메소드로 상세 프로퍼티 정의하는 형식
- `reloadData()` 호출 위치 변경
  - CollectionView의 data 프로퍼티에 property observer `didSet` 활용
- 작성하기뷰에서 n번째 pet 등록 후 홈뷰 돌아왔을 때 n번째 pet 선택되는 기능 구현
- MVC 아키텍처에 맞게 VC 와 V 분리

### ❗️PR Point
- 컨벤션을 ,,조금 바꿨씁니다... 다들 이 컨벤션 어떤지...?
  - `setUI()` -> `style()`
  - `setLayout()` -> `hierarchy()`, `layout()`
  - New: `gesture()`
  - New: `register()`
  -  API관련: `request***API()`

- 희재, 승찬님 코드처럼 loadView에 view만 할당하면서 VC 와 V 를 분리하였습니다만~
   VC에서 호출해야하는 V 앞에 rootView. 이 너무 거머리처럼 어두에 붙어있는게 너무 가독성이 떨어져용 ㅠㅜㅜㅠ 어쩌면 좋징

### 📸 스크린샷
응 스샷 첨부 할거 없어~

closed #64 
