### PR TITLE
[Refactor] #91 - 프로필 편집뷰 코드 리팩토링

### DIFF
--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		4C6B186E296DBFE40059840D /* RecordAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6B186D296DBFE40059840D /* RecordAlertViewController.swift */; };
 		4C8A7C33297063F400783979 /* OnboardingInviteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */; };
 		870D062A297BEB7900ADAD04 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870D0629297BEB7900ADAD04 /* HomeView.swift */; };
+		8718A06429AD3445001C7460 /* EditProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06329AD3445001C7460 /* EditProfileRequest.swift */; };
 		871EA33C296F3E6200D0E8CC /* HomePetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33B296F3E6200D0E8CC /* HomePetResult.swift */; };
 		871EA33E296F529C00D0E8CC /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33D296F529C00D0E8CC /* UIImageView+.swift */; };
 		871EA340296F6E5000D0E8CC /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33F296F6E5000D0E8CC /* BaseAPI.swift */; };
@@ -184,6 +185,7 @@
 		4C6B186D296DBFE40059840D /* RecordAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordAlertViewController.swift; sourceTree = "<group>"; };
 		4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteResult.swift; sourceTree = "<group>"; };
 		870D0629297BEB7900ADAD04 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		8718A06329AD3445001C7460 /* EditProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequest.swift; sourceTree = "<group>"; };
 		871EA33B296F3E6200D0E8CC /* HomePetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetResult.swift; sourceTree = "<group>"; };
 		871EA33D296F529C00D0E8CC /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		871EA33F296F6E5000D0E8CC /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
@@ -736,6 +738,7 @@
 		87A76AAF295F6F040096F669 /* APIModel */ = {
 			isa = PBXGroup;
 			children = (
+				8718A06329AD3445001C7460 /* EditProfileRequest.swift */,
 				D26C68EF296F693E0088DC9A /* MyResult.swift */,
 			);
 			path = APIModel;
@@ -1080,6 +1083,7 @@
 				D26C85E52968CB2F00AEAF9B /* OnboardingAgreementTableViewCell.swift in Sources */,
 				D23503032964728700F01101 /* MyAppInformationTableViewCell.swift in Sources */,
 				D26C68F22970AD820088DC9A /* HomeNoticeViewController.swift in Sources */,
+				8718A06429AD3445001C7460 /* EditProfileRequest.swift in Sources */,
 				8782C7E62968C0F000C9324B /* HomePetModel.swift in Sources */,
 				8782C7F3296CC13A00C9324B /* HomeCommentCollectionViewCell.swift in Sources */,
 				D23502FB2961F44700F01101 /* MySettingTableViewCell.swift in Sources */,

--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		870D062A297BEB7900ADAD04 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870D0629297BEB7900ADAD04 /* HomeView.swift */; };
 		8718A06429AD3445001C7460 /* EditProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06329AD3445001C7460 /* EditProfileRequest.swift */; };
 		8718A06829ADB423001C7460 /* GalleryAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06729ADB423001C7460 /* GalleryAlertController.swift */; };
+		8718A06A29ADE6E8001C7460 /* BaseTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06929ADE6E8001C7460 /* BaseTextField.swift */; };
 		871EA33C296F3E6200D0E8CC /* HomePetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33B296F3E6200D0E8CC /* HomePetResult.swift */; };
 		871EA33E296F529C00D0E8CC /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33D296F529C00D0E8CC /* UIImageView+.swift */; };
 		871EA340296F6E5000D0E8CC /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33F296F6E5000D0E8CC /* BaseAPI.swift */; };
@@ -188,6 +189,7 @@
 		870D0629297BEB7900ADAD04 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		8718A06329AD3445001C7460 /* EditProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequest.swift; sourceTree = "<group>"; };
 		8718A06729ADB423001C7460 /* GalleryAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAlertController.swift; sourceTree = "<group>"; };
+		8718A06929ADE6E8001C7460 /* BaseTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTextField.swift; sourceTree = "<group>"; };
 		871EA33B296F3E6200D0E8CC /* HomePetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetResult.swift; sourceTree = "<group>"; };
 		871EA33D296F529C00D0E8CC /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		871EA33F296F6E5000D0E8CC /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 				8765549E295846F3006BBDA9 /* ZoocTabBarController.swift */,
 				876554A2295848D5006BBDA9 /* BaseViewController.swift */,
 				D2DD45C6297D9612001722A1 /* BaseButton.swift */,
+				8718A06929ADE6E8001C7460 /* BaseTextField.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1151,6 +1154,7 @@
 				D21DADC1298BFF2700CCC089 /* MyPetRegisterViewModel.swift in Sources */,
 				D27D9568296CB5930097CD03 /* OnboardingReInviteFamilyView.swift in Sources */,
 				D27D9566296CA99B0097CD03 /* OnboardingInviteFamilyCompletedViewController.swift in Sources */,
+				8718A06A29ADE6E8001C7460 /* BaseTextField.swift in Sources */,
 				8747389E299E84B400C4CC52 /* EmojiBottomSheetViewController.swift in Sources */,
 				8718A06829ADB423001C7460 /* GalleryAlertController.swift in Sources */,
 				D26C85FA296B109500AEAF9B /* OnboardingChooseFamilyRoleViewController.swift in Sources */,

--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		4C8A7C33297063F400783979 /* OnboardingInviteResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */; };
 		870D062A297BEB7900ADAD04 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870D0629297BEB7900ADAD04 /* HomeView.swift */; };
 		8718A06429AD3445001C7460 /* EditProfileRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06329AD3445001C7460 /* EditProfileRequest.swift */; };
+		8718A06829ADB423001C7460 /* GalleryAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718A06729ADB423001C7460 /* GalleryAlertController.swift */; };
 		871EA33C296F3E6200D0E8CC /* HomePetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33B296F3E6200D0E8CC /* HomePetResult.swift */; };
 		871EA33E296F529C00D0E8CC /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33D296F529C00D0E8CC /* UIImageView+.swift */; };
 		871EA340296F6E5000D0E8CC /* BaseAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871EA33F296F6E5000D0E8CC /* BaseAPI.swift */; };
@@ -186,6 +187,7 @@
 		4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteResult.swift; sourceTree = "<group>"; };
 		870D0629297BEB7900ADAD04 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		8718A06329AD3445001C7460 /* EditProfileRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileRequest.swift; sourceTree = "<group>"; };
+		8718A06729ADB423001C7460 /* GalleryAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAlertController.swift; sourceTree = "<group>"; };
 		871EA33B296F3E6200D0E8CC /* HomePetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetResult.swift; sourceTree = "<group>"; };
 		871EA33D296F529C00D0E8CC /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		871EA33F296F6E5000D0E8CC /* BaseAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAPI.swift; sourceTree = "<group>"; };
@@ -613,6 +615,7 @@
 				D26C85DA2968A12000AEAF9B /* MyNoticeSettingView.swift */,
 				D26C85D829689D0800AEAF9B /* MyDeleteAccountAlertViewController.swift */,
 				D26C68E2296DE4F80088DC9A /* MyRegisterPetView.swift */,
+				8718A06729ADB423001C7460 /* GalleryAlertController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1149,6 +1152,7 @@
 				D27D9568296CB5930097CD03 /* OnboardingReInviteFamilyView.swift in Sources */,
 				D27D9566296CA99B0097CD03 /* OnboardingInviteFamilyCompletedViewController.swift in Sources */,
 				8747389E299E84B400C4CC52 /* EmojiBottomSheetViewController.swift in Sources */,
+				8718A06829ADB423001C7460 /* GalleryAlertController.swift in Sources */,
 				D26C85FA296B109500AEAF9B /* OnboardingChooseFamilyRoleViewController.swift in Sources */,
 				4C6B186E296DBFE40059840D /* RecordAlertViewController.swift in Sources */,
 				87A76AA5295F6EC40096F669 /* HomeAPI.swift in Sources */,

--- a/ZOOC/ZOOC/Data/My/APIModel/EditProfileRequest.swift
+++ b/ZOOC/ZOOC/Data/My/APIModel/EditProfileRequest.swift
@@ -1,0 +1,22 @@
+//
+//  MyEditProfileModel.swift
+//  ZOOC
+//
+//  Created by 장석우 on 2023/02/28.
+//
+
+import UIKit
+
+struct EditProfileRequest {
+    var hasPhoto: Bool
+    var nickName: String
+    var profileImage: UIImage?
+    
+    init(hasPhoto: Bool = true,
+         nickName: String = "",
+         profileImage: UIImage? = nil) {
+        self.hasPhoto = hasPhoto
+        self.nickName = nickName
+        self.profileImage = profileImage
+    }
+}

--- a/ZOOC/ZOOC/Data/My/APIModel/MyResult.swift
+++ b/ZOOC/ZOOC/Data/My/APIModel/MyResult.swift
@@ -9,13 +9,13 @@ import Foundation
 
 // MARK: - MyResult
 struct MyResult: Codable {
-    let user: MyUser
-    let familyMember: [MyUser]
-    let pet: [MyPet]
+    let user: UserResult
+    let familyMember: [UserResult]
+    let pet: [PetResult]
 }
 
 // MARK: - User
-struct MyUser: Codable {
+struct UserResult: Codable {
     let id: Int
     var nickName: String
     var photo: String?
@@ -28,7 +28,7 @@ struct MyUser: Codable {
 }
 
 // MARK: - Pet
-struct MyPet: Codable {
+struct PetResult: Codable {
     let id: Int
     let name: String
     let photo: String?

--- a/ZOOC/ZOOC/Network/My/MyAPI.swift
+++ b/ZOOC/ZOOC/Network/My/MyAPI.swift
@@ -31,7 +31,7 @@ extension MyAPI{
                                              nickName: nickName,
                                              photo: photo)) { result in
             self.disposeNetwork(result,
-                                dataModel: MyUser.self,
+                                dataModel: UserResult.self,
                                 completion: completion)
         }
     }

--- a/ZOOC/ZOOC/Network/My/MyAPI.swift
+++ b/ZOOC/ZOOC/Network/My/MyAPI.swift
@@ -23,18 +23,29 @@ extension MyAPI{
         }
     }
     
-    func patchMyProfile(isPhoto: Bool,
-                        nickName: String,
-                        photo: UIImage?,
+//    func patchMyProfile(isPhoto: Bool,
+//                        nickName: String,
+//                        photo: UIImage?,
+//                        completion: @escaping (NetworkResult<Any>) -> Void){
+//        myProvider.request(.patchUserProfile(isPhoto: isPhoto,
+//                                             nickName: nickName,
+//                                             photo: photo)) { result in
+//            self.disposeNetwork(result,
+//                                dataModel: UserResult.self,
+//                                completion: completion)
+//        }
+//    }
+    
+    func patchMyProfile(requset: EditProfileRequest,
                         completion: @escaping (NetworkResult<Any>) -> Void){
-        myProvider.request(.patchUserProfile(isPhoto: isPhoto,
-                                             nickName: nickName,
-                                             photo: photo)) { result in
+        myProvider.request(.patchUserProfile(requset)) { result in
             self.disposeNetwork(result,
                                 dataModel: UserResult.self,
                                 completion: completion)
         }
     }
+    
+    
     
     func deleteAccount(completion: @escaping (NetworkResult<Any>) -> Void) {
         myProvider.request(.deleteAccount) { (result) in

--- a/ZOOC/ZOOC/Network/My/MyService.swift
+++ b/ZOOC/ZOOC/Network/My/MyService.swift
@@ -11,7 +11,8 @@ import Moya
 
 enum MyService {
     case getMyPageData
-    case patchUserProfile(isPhoto: Bool, nickName: String, photo: UIImage?)
+    //case patchUserProfile(isPhoto: Bool, nickName: String, photo: UIImage?)
+    case patchUserProfile(_ request: EditProfileRequest)
     case deleteAccount
 }
 
@@ -20,7 +21,7 @@ extension MyService: BaseTargetType {
         switch self {
         case .getMyPageData:
             return "/family/mypage"
-        case .patchUserProfile(isPhoto: let isPhoto, nickName: let nickName, photo: let photo):
+        case .patchUserProfile:
             return "/user/profile"
         case .deleteAccount:
             return "/user"
@@ -43,14 +44,15 @@ extension MyService: BaseTargetType {
         switch self {
         case .getMyPageData:
             return .requestPlain
-        case .patchUserProfile(isPhoto: let isPhoto, nickName: let nickName, photo: let photo):
+            
+        case .patchUserProfile(let request):
             
             var multipartFormData: [MultipartFormData] = []
             
-            let nickNameData = MultipartFormData(provider: .data(nickName.data(using: String.Encoding.utf8)!),
+            let nickNameData = MultipartFormData(provider: .data(request.nickName.data(using: String.Encoding.utf8)!),
                                                            name: "nickName",
                                                            mimeType: "application/json")
-            if let photo = photo{
+            if let photo = request.profileImage{
                 print("포토있음")
                 let photo = photo.jpegData(compressionQuality: 1.0) ?? Data()
                 let imageData = MultipartFormData(provider: .data(photo),
@@ -62,7 +64,7 @@ extension MyService: BaseTargetType {
           
             
             multipartFormData.append(nickNameData)
-            return .uploadCompositeMultipart(multipartFormData, urlParameters: ["photo": isPhoto ? "true" : "false"])
+            return .uploadCompositeMultipart(multipartFormData, urlParameters: ["photo": request.hasPhoto ? "true" : "false"])
 
 
         case .deleteAccount:

--- a/ZOOC/ZOOC/Presentation/Base/BaseTextField.swift
+++ b/ZOOC/ZOOC/Presentation/Base/BaseTextField.swift
@@ -1,0 +1,33 @@
+//
+//  BaseTextField.swift
+//  ZOOC
+//
+//  Created by 장석우 on 2023/02/28.
+//
+
+import UIKit
+
+class BaseTextField: UITextField {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configure()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        super.point(inside: point, with: event)
+
+        /// 모든 방향에 20만큼 터치 영역 증가
+        /// dx: x축이 dx만큼 증가 (음수여야 증가)
+        let touchArea = bounds.insetBy(dx: -20, dy: -30)
+        return touchArea.contains(point)
+    }
+
+    func configure() {}
+    func bind() {}
+}

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyFamilyCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyFamilyCollectionViewCell.swift
@@ -66,7 +66,7 @@ final class MyFamilyCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    public func dataBind(data: MyUser, myProfileData: MyUser?) {
+    public func dataBind(data: UserResult, myProfileData: UserResult?) {
         familyNameLabel.text = data.nickName
         data.photo == nil ? setDefaultProfileImage() : setFamilyMemberProfileImage(photo: data.photo!)
         data.nickName == myProfileData?.nickName ? configMyProfile() : configFamilyProfile()

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyFamilySectionCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyFamilySectionCollectionViewCell.swift
@@ -14,8 +14,8 @@ final class MyFamilySectionCollectionViewCell: UICollectionViewCell {
     
     //MARK: - Properties
     
-    private var myProfileData: MyUser?
-    private var myFamilyData: [MyUser] = []
+    private var myProfileData: UserResult?
+    private var myFamilyData: [UserResult] = []
     
     //MARK: - UI Components
     
@@ -130,7 +130,7 @@ final class MyFamilySectionCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    public func dataBind(myFamilyData: [MyUser], myProfileData: MyUser?) {
+    public func dataBind(myFamilyData: [UserResult], myProfileData: UserResult?) {
         self.myProfileData = myProfileData
         self.myFamilyData = myFamilyData
         familyCountLabel.text = "\(myFamilyData.count)/8"

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyPetCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyPetCollectionViewCell.swift
@@ -68,7 +68,7 @@ final class MyPetCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    public func dataBind(data: MyPet) {
+    public func dataBind(data: PetResult) {
         petNameLabel.text = data.name
         data.photo == nil ? setDefaultPetProfileImage() : setPetMemberProfileImage(photo: data.photo!)
     }

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyPetSectionCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyPetSectionCollectionViewCell.swift
@@ -22,7 +22,7 @@ final class MyPetSectionCollectionViewCell: UICollectionViewCell {
     
     var delegate: MyRegisterPetButtonTappedDelegate?
     private let myRegisterPetView = MyRegisterPetView()
-    private lazy var myPetMemberData: [MyPet] = []
+    private lazy var myPetMemberData: [PetResult] = []
     
     //MARK: - UI Components
     
@@ -112,7 +112,7 @@ final class MyPetSectionCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    public func dataBind(myPetMemberData : [MyPet]) {
+    public func dataBind(myPetMemberData : [PetResult]) {
         self.myPetMemberData = myPetMemberData
         petCountLabel.text = "\(myPetMemberData.count)/4"
         self.petCollectionView.reloadData()

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyProfileSectionCollectionViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyProfileSectionCollectionViewCell.swift
@@ -88,7 +88,7 @@ final class MyProfileSectionCollectionViewCell: UICollectionViewCell  {
         }
     }
     
-    func dataBind(data: MyUser?) {
+    func dataBind(data: UserResult?) {
         profileNameLabel.text = data?.nickName
         data?.photo == nil ? setDefaultProfileImage() : setProfileImage(photo: (data?.photo)!)
     }

--- a/ZOOC/ZOOC/Presentation/My/Cell/MyRegisteredPetTableViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/My/Cell/MyRegisteredPetTableViewCell.swift
@@ -65,7 +65,7 @@ final class MyRegisteredPetTableViewCell: UITableViewCell {
         }
     }
     
-    func dataBind(data: MyPet, index: Int, petData: [MyPet]) {
+    func dataBind(data: PetResult, index: Int, petData: [PetResult]) {
         petProfileNameLabel.text = data.name
         data.photo == nil ? setDefaultPetProfileImage() : setPetMemberProfileImage(photo: data.photo!)
     }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyAppInformationViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyAppInformationViewController.swift
@@ -10,11 +10,11 @@ import UIKit
 import SnapKit
 import Then
 
-final class AppInformationViewController: BaseViewController {
+final class MyAppInformationViewController: BaseViewController {
     
     //MARK: - Properties
     
-    private lazy var appInformationView = AppInformationView()
+    private lazy var appInformationView = MyAppInformationView()
     
     //MARK: - Life Cycle
     
@@ -50,7 +50,7 @@ final class AppInformationViewController: BaseViewController {
 
 //MARK: - UITableViewDelegate
 
-extension AppInformationViewController: UITableViewDelegate {
+extension MyAppInformationViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 63
     }
@@ -58,7 +58,7 @@ extension AppInformationViewController: UITableViewDelegate {
 
 //MARK: - UITableViewDataSource
 
-extension AppInformationViewController: UITableViewDataSource {
+extension MyAppInformationViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return MyAppInformationModel.appInformationData.count
     }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -17,8 +17,8 @@ final class MyEditProfileViewController: BaseViewController {
     private var myProfileData: UserResult?
     
     private var isPhoto: Bool = true
-    private var myProfileImage: UIImage?
-    private var myProfileNickName: String?
+    private var profileImage: UIImage?
+    private var nickName: String?
     
     //MARK: - UIComponents
     
@@ -48,11 +48,16 @@ final class MyEditProfileViewController: BaseViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nil)
     }
     
-    func dataSend(data: UserResult?) {
+    func dataBind(data: UserResult?) {
         rootView.nameTextField.placeholder = data?.nickName
-        data?.photo == nil ? setDefaultProfileImage() : setFamilyMemberProfileImage(photo: (data?.photo!)!)
-        guard let name = data?.nickName else { return }
-        myProfileNickName = name
+        
+        if let photoURL = data?.photo{
+            rootView.profileImageButton.kfSetButtonImage(url: photoURL)
+        } else {
+            rootView.profileImageButton.setImage(Image.defaultProfile, for: .normal)
+        }
+        
+        self.nickName = data?.nickName
     }
     
     //MARK: - Action Method
@@ -108,10 +113,10 @@ final class MyEditProfileViewController: BaseViewController {
     
     @objc func editCompleteButtonDidTap(){
         guard let text = rootView.nameTextField.text else { return }
-        myProfileNickName = text
+        nickName = text
         MyAPI.shared.patchMyProfile(isPhoto: isPhoto,
-                                    nickName: myProfileNickName ?? "닉네임이 없습니다.",
-                                    photo: myProfileImage) { result in
+                                    nickName: nickName ?? "닉네임이 없습니다.",
+                                    photo: profileImage) { result in
             guard let result = self.validateResult(result) as? UserResult else { return }
             print(result)
             
@@ -139,14 +144,6 @@ extension MyEditProfileViewController {
         rootView.numberOfNameCharactersLabel.text = "\(textCount)/10"
     }
     
-    func setDefaultProfileImage() {
-        rootView.profileImageButton.setImage(Image.defaultProfile, for: .normal)
-    }
-    
-    func setFamilyMemberProfileImage(photo: String) {
-        rootView.profileImageButton.kfSetButtonImage(url: photo)
-    }
-    
     private func popToMyProfileView() {
         guard let beforeVC = self.navigationController?.previousViewController as? MyViewController else { return }
         beforeVC.getMyPageAPI()
@@ -159,6 +156,6 @@ extension MyEditProfileViewController: UIImagePickerControllerDelegate, UINaviga
         
         guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
         rootView.profileImageButton.setImage(image, for: .normal)
-        self.myProfileImage = image
+        self.profileImage = image
     }
 }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -158,6 +158,8 @@ extension MyEditProfileViewController: UIImagePickerControllerDelegate, UINaviga
         
         guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
         rootView.profileImageButton.setImage(image, for: .normal)
+        rootView.completeButton.backgroundColor = .zoocGradientGreen
+        rootView.completeButton.isEnabled = true
         self.editMyProfileData.profileImage = image
     }
 }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -54,6 +54,7 @@ final class MyEditProfileViewController: BaseViewController {
     func dataBind(data: UserResult?) {
         rootView.nameTextField.text = data?.nickName
         editMyProfileData.nickName = data?.nickName ?? ""
+        textFieldIsEmpty(textCount: data?.nickName.count ?? 0)
         
         if let photoURL = data?.photo{
             rootView.profileImageButton.kfSetButtonImage(url: photoURL)

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -20,6 +20,7 @@ final class MyEditProfileViewController: BaseViewController {
     //MARK: - UIComponents
     
     private lazy var rootView = MyEditProfileView()
+    private let galleryAlertController = GalleryAlertController()
     
     //MARK: - Life Cycle
     
@@ -30,17 +31,22 @@ final class MyEditProfileViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        delegate()
         target()
     }
     
     //MARK: - Custom Method
+    
+    private func delegate() {
+        galleryAlertController.delegate = self
+    }
     
     private func target() {
         rootView.backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
         
         rootView.completeButton.addTarget(self, action: #selector(editCompleteButtonDidTap), for: .touchUpInside)
         
-        rootView.profileImageButton.addTarget(self, action: #selector(chooseProfileImage) , for: .touchUpInside)
+        rootView.profileImageButton.addTarget(self, action: #selector(profileImageButtonDidTap) , for: .touchUpInside)
         
         NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nil)
     }
@@ -65,31 +71,9 @@ final class MyEditProfileViewController: BaseViewController {
     
     //MARK: - Action Method
     
-    @objc func chooseProfileImage() {
-        let actionSheetController = UIAlertController()
-        
-        let presentToGalleryButton = UIAlertAction(title: "사진 보관함", style: .default, handler: {action in
-            print("ok")
-            let imagePicker = UIImagePickerController()
-            imagePicker.delegate = self
-            imagePicker.sourceType = .photoLibrary
-            self.present(imagePicker, animated: true)
-        })
-        
-        let deleteProfileImageButton = UIAlertAction(title: "사진 삭제", style: .destructive, handler: {action in
-            self.rootView.profileImageButton.setImage(Image.defaultProfilePet, for: .normal)
-            //self.isPhoto = false
-            self.editMyProfileData.hasPhoto = false
-        })
-        
-        let cancleButton = UIAlertAction(title: "취소", style: .cancel, handler: {action in
-            print("cancel")
-        })
-        
-        actionSheetController.addAction(presentToGalleryButton)
-        actionSheetController.addAction(deleteProfileImageButton)
-        actionSheetController.addAction(cancleButton)
-        self.present(actionSheetController, animated: true)
+    @objc
+    private func profileImageButtonDidTap() {
+        present(galleryAlertController,animated: true)
     }
     
     @objc func backButtonDidTap() {
@@ -123,18 +107,18 @@ final class MyEditProfileViewController: BaseViewController {
 }
 
 extension MyEditProfileViewController {
-    func textFieldIsFull() {
+    private func textFieldIsFull() {
         rootView.numberOfNameCharactersLabel.text = "10/10"
     }
     
-    func textFieldIsWritten(textCount: Int) {
+    private func textFieldIsWritten(textCount: Int) {
         rootView.underLineView.backgroundColor = .zoocGradientGreen
         rootView.completeButton.backgroundColor = .zoocGradientGreen
         rootView.completeButton.isEnabled = true
         rootView.numberOfNameCharactersLabel.text = "\(textCount)/10"
     }
     
-    func textFieldIsEmpty(textCount: Int) {
+    private func textFieldIsEmpty(textCount: Int) {
         rootView.underLineView.backgroundColor = .zoocGray1
         rootView.completeButton.backgroundColor = .zoocGray1
         rootView.completeButton.isEnabled = false
@@ -148,7 +132,27 @@ extension MyEditProfileViewController {
     }
 }
 
-extension MyEditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate{
+//MARK: - GalleryAlertControllerDelegate
+
+extension MyEditProfileViewController: GalleryAlertControllerDelegate {
+    func galleryButtonDidTap() {
+        let imagePicker = UIImagePickerController()
+        imagePicker.delegate = self
+        imagePicker.sourceType = .photoLibrary
+        present(imagePicker, animated: true)
+    }
+    
+    func deleteButtonDidTap() {
+        rootView.profileImageButton.setImage(Image.defaultProfile, for: .normal)
+        editMyProfileData.hasPhoto = false
+    }
+    
+    
+}
+
+//MARK: - UIImagePickerControllerDelegate
+
+extension MyEditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
         guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -10,21 +10,24 @@ import UIKit
 import SnapKit
 import Then
 
-final class EditProfileViewController: BaseViewController {
+final class MyEditProfileViewController: BaseViewController {
     
     //MARK: - Properties
     
-    private lazy var editProfileView = EditProfileView()
-    private var myProfileData: MyUser?
+    private var myProfileData: UserResult?
     
     private var isPhoto: Bool = true
     private var myProfileImage: UIImage?
     private var myProfileNickName: String?
     
+    //MARK: - UIComponents
+    
+    private lazy var rootView = MyEditProfileView()
+    
     //MARK: - Life Cycle
     
     override func loadView() {
-        self.view = editProfileView
+        self.view = rootView
     }
     
     override func viewDidLoad() {
@@ -36,17 +39,17 @@ final class EditProfileViewController: BaseViewController {
     //MARK: - Custom Method
     
     private func target() {
-        editProfileView.backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
+        rootView.backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
         
-        editProfileView.editCompletedButton.addTarget(self, action: #selector(editCompleteButtonDidTap), for: .touchUpInside)
+        rootView.completeButton.addTarget(self, action: #selector(editCompleteButtonDidTap), for: .touchUpInside)
         
-        editProfileView.editProfileImageButton.addTarget(self, action: #selector(chooseProfileImage) , for: .touchUpInside)
+        rootView.profileImageButton.addTarget(self, action: #selector(chooseProfileImage) , for: .touchUpInside)
         
         NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextField.textDidChangeNotification, object: nil)
     }
     
-    func dataSend(data: MyUser?) {
-        editProfileView.editProfileNameTextField.placeholder = data?.nickName
+    func dataSend(data: UserResult?) {
+        rootView.nameTextField.placeholder = data?.nickName
         data?.photo == nil ? setDefaultProfileImage() : setFamilyMemberProfileImage(photo: (data?.photo!)!)
         guard let name = data?.nickName else { return }
         myProfileNickName = name
@@ -66,7 +69,7 @@ final class EditProfileViewController: BaseViewController {
         })
         
         let deleteProfileImageButton = UIAlertAction(title: "사진 삭제", style: .destructive, handler: {action in
-            self.editProfileView.editProfileImageButton.setImage(Image.defaultProfilePet, for: .normal)
+            self.rootView.profileImageButton.setImage(Image.defaultProfilePet, for: .normal)
             self.isPhoto = false
         })
         
@@ -104,13 +107,12 @@ final class EditProfileViewController: BaseViewController {
     }
     
     @objc func editCompleteButtonDidTap(){
-        guard let text = editProfileView.editProfileNameTextField.text else { return }
+        guard let text = rootView.nameTextField.text else { return }
         myProfileNickName = text
         MyAPI.shared.patchMyProfile(isPhoto: isPhoto,
                                     nickName: myProfileNickName ?? "닉네임이 없습니다.",
-                                    photo: myProfileImage)
-        { result in
-            guard let result = self.validateResult(result) as? MyUser else { return }
+                                    photo: myProfileImage) { result in
+            guard let result = self.validateResult(result) as? UserResult else { return }
             print(result)
             
             self.popToMyProfileView()
@@ -118,31 +120,31 @@ final class EditProfileViewController: BaseViewController {
     }
 }
 
-extension EditProfileViewController {
+extension MyEditProfileViewController {
     func textFieldIsFull() {
-        editProfileView.profileNameCountLabel.text = "10/10"
+        rootView.numberOfNameCharactersLabel.text = "10/10"
     }
     
     func textFieldIsWritten(textCount: Int) {
-        editProfileView.profileNameTextFieldUnderLineView.backgroundColor = .zoocGradientGreen
-        editProfileView.editCompletedButton.backgroundColor = .zoocGradientGreen
-        editProfileView.editCompletedButton.isEnabled = true
-        editProfileView.profileNameCountLabel.text = "\(textCount)/10"
+        rootView.underLineView.backgroundColor = .zoocGradientGreen
+        rootView.completeButton.backgroundColor = .zoocGradientGreen
+        rootView.completeButton.isEnabled = true
+        rootView.numberOfNameCharactersLabel.text = "\(textCount)/10"
     }
     
     func textFieldIsEmpty(textCount: Int) {
-        editProfileView.profileNameTextFieldUnderLineView.backgroundColor = .zoocGray1
-        editProfileView.editCompletedButton.backgroundColor = .zoocGray1
-        editProfileView.editCompletedButton.isEnabled = false
-        editProfileView.profileNameCountLabel.text = "\(textCount)/10"
+        rootView.underLineView.backgroundColor = .zoocGray1
+        rootView.completeButton.backgroundColor = .zoocGray1
+        rootView.completeButton.isEnabled = false
+        rootView.numberOfNameCharactersLabel.text = "\(textCount)/10"
     }
     
     func setDefaultProfileImage() {
-        editProfileView.editProfileImageButton.setImage(Image.defaultProfile, for: .normal)
+        rootView.profileImageButton.setImage(Image.defaultProfile, for: .normal)
     }
     
     func setFamilyMemberProfileImage(photo: String) {
-        editProfileView.editProfileImageButton.kfSetButtonImage(url: photo)
+        rootView.profileImageButton.kfSetButtonImage(url: photo)
     }
     
     private func popToMyProfileView() {
@@ -152,11 +154,11 @@ extension EditProfileViewController {
     }
 }
 
-extension EditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate{
+extension MyEditProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate{
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
         guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
-        editProfileView.editProfileImageButton.setImage(image, for: .normal)
+        rootView.profileImageButton.setImage(image, for: .normal)
         self.myProfileImage = image
     }
 }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyRegisterPetViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyRegisterPetViewController.swift
@@ -18,7 +18,7 @@ final class MyRegisterPetViewController: UIViewController {
     private let myPetRegisterViewModel: MyPetRegisterViewModel
     private let defaultpetProfile = MyPetRegisterModel(profileName: "", profileImage: Image.defaultProfilePet)
     
-    private var myPetMemberData: [MyPet] = []
+    private var myPetMemberData: [PetResult] = []
     
     //MARK: - Life Cycle
     
@@ -56,7 +56,7 @@ final class MyRegisterPetViewController: UIViewController {
         myRegisterPetView.registerPetButton.addTarget(self, action: #selector(registerPetButtonDidTap), for: .touchUpInside)
     }
     
-    func dataSend(myPetMemberData: [MyPet]) {
+    func dataSend(myPetMemberData: [PetResult]) {
         self.myPetMemberData = myPetMemberData
     }
     

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
@@ -200,7 +200,7 @@ extension MyViewController {
     private func pushToEditProfileView() {
         let editProfileViewController = MyEditProfileViewController()
         editProfileViewController.hidesBottomBarWhenPushed = true
-        editProfileViewController.dataSend(data: myProfileData)
+        editProfileViewController.dataBind(data: myProfileData)
         
         self.navigationController?.pushViewController(editProfileViewController, animated: true)
     }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
@@ -15,9 +15,9 @@ final class MyViewController: BaseViewController {
     
     //MARK: - Properties
     
-    private var myFamilyMemberData: [MyUser] = []
-    private var myPetMemberData: [MyPet] = []
-    private var myProfileData: MyUser?
+    private var myFamilyMemberData: [UserResult] = []
+    private var myPetMemberData: [PetResult] = []
+    private var myProfileData: UserResult?
     
     //MARK: - UI Components
     
@@ -48,7 +48,7 @@ final class MyViewController: BaseViewController {
         myView.myCollectionView.dataSource = self
     }
     
-    func dataSend(myprofileData: MyUser?) {
+    func dataSend(myprofileData: UserResult?) {
         guard let nickNameData = myProfileData?.nickName else { return }
         guard let photoData = myProfileData?.photo else { return }
         myView.myCollectionView.reloadData()
@@ -198,7 +198,7 @@ extension MyViewController: MyRegisterPetButtonTappedDelegate {
 
 extension MyViewController {
     private func pushToEditProfileView() {
-        let editProfileViewController = EditProfileViewController()
+        let editProfileViewController = MyEditProfileViewController()
         editProfileViewController.hidesBottomBarWhenPushed = true
         editProfileViewController.dataSend(data: myProfileData)
         
@@ -206,7 +206,7 @@ extension MyViewController {
     }
     
     private func pushToAppInformationView() {
-        let appInformationViewController = AppInformationViewController()
+        let appInformationViewController = MyAppInformationViewController()
         appInformationViewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(appInformationViewController, animated: true)
     }

--- a/ZOOC/ZOOC/Presentation/My/View/GalleryAlertController.swift
+++ b/ZOOC/ZOOC/Presentation/My/View/GalleryAlertController.swift
@@ -1,0 +1,69 @@
+//
+//  GalleryAlertViewController.swift
+//  ZOOC
+//
+//  Created by 장석우 on 2023/02/28.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+protocol GalleryAlertControllerDelegate: AnyObject {
+    func galleryButtonDidTap()
+    func deleteButtonDidTap()
+}
+
+final class GalleryAlertController : UIAlertController {
+    
+    //MARK: - Properties
+    
+    weak var delegate: GalleryAlertControllerDelegate?
+    
+    //MARK: - UI Components
+    
+    private lazy var galleryAction = UIAlertAction(title: "사진 보관함", style: .default) { action in
+        self.delegate?.galleryButtonDidTap()
+    }
+    
+    private lazy var deleteAction = UIAlertAction(title: "사진 삭제", style: .destructive) { action in
+        self.delegate?.deleteButtonDidTap()
+    }
+    private let cancleAction = UIAlertAction(title: "취소", style: .cancel)
+    
+    //MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        target()
+        style()
+        hierarchy()
+        layout()
+    }
+    
+    //MARK: - Custom Method
+    
+    private func target() {
+        addAction(galleryAction)
+        addAction(deleteAction)
+        addAction(cancleAction)
+    }
+    
+    private func style() {
+        
+    }
+    
+    private func hierarchy() {
+        
+    }
+    
+    private func layout() {
+        
+    }
+    
+    //MARK: - Action Method
+    
+}
+

--- a/ZOOC/ZOOC/Presentation/My/View/MyAppInformationView.swift
+++ b/ZOOC/ZOOC/Presentation/My/View/MyAppInformationView.swift
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class AppInformationView: UIView {
+final class MyAppInformationView: UIView {
     
     //MARK: - UI Components
     

--- a/ZOOC/ZOOC/Presentation/My/View/MyEditProfileView.swift
+++ b/ZOOC/ZOOC/Presentation/My/View/MyEditProfileView.swift
@@ -10,18 +10,19 @@ import UIKit
 import SnapKit
 import Then
 
-final class EditProfileView: UIView {
+final class MyEditProfileView: UIView {
     
     //MARK: - UI Components
     
     public var backButton = UIButton()
-    private var appInformationLabel = UILabel()
-    public var editProfileImageButton = UIButton()
-    private var editProfileCameraIconImageView = UIImageView()
-    public var editProfileNameTextField = UITextField()
-    public var profileNameTextFieldUnderLineView = UIView()
-    public var profileNameCountLabel = UILabel()
-    public var editCompletedButton = UIButton()
+    private var titleLabel = UILabel()
+    
+    public var profileImageButton = UIButton()
+    private var cameraIconImageView = UIImageView()
+    public var nameTextField = UITextField()
+    public var underLineView = UIView()
+    public var numberOfNameCharactersLabel = UILabel()
+    public var completeButton = UIButton()
     
     //MARK: - Life Cycles
     
@@ -46,41 +47,41 @@ final class EditProfileView: UIView {
             $0.setImage(Image.back, for: .normal)
         }
 
-        appInformationLabel.do {
+        titleLabel.do {
             $0.font = .zoocHeadLine
             $0.text = "프로필 수정"
             $0.textColor = .zoocDarkGray2
         }
         
-        editProfileImageButton.do {
+        profileImageButton.do {
             $0.setImage(Image.logoSymbol, for: .normal)
             $0.makeCornerRadius(ratio: 54.5)
             $0.contentMode = .scaleAspectFill
         }
         
-        editProfileCameraIconImageView.do {
+        cameraIconImageView.do {
             $0.image = Image.cameraCircleGreen
             $0.contentMode = .scaleAspectFill
             $0.makeCornerRadius(ratio: 17.5)
         }
         
-        editProfileNameTextField.do {
+        nameTextField.do {
             $0.textAlignment = .center
             $0.font = .zoocHeadLine
             $0.tintColor = .zoocGradientGreen
         }
         
-        profileNameTextFieldUnderLineView.do {
+        underLineView.do {
             $0.backgroundColor = .zoocGray1
         }
         
-        profileNameCountLabel.do {
+        numberOfNameCharactersLabel.do {
             $0.font = .zoocCaption
             $0.text = "/10"
             $0.textColor = .zoocGray3
         }
         
-        editCompletedButton.do {
+        completeButton.do {
             $0.backgroundColor = .zoocGray1
             $0.setTitle("완료", for: .normal)
             $0.makeCornerRadius(ratio: 27)
@@ -89,13 +90,13 @@ final class EditProfileView: UIView {
     
     private func hierarchy() {
         addSubviews(backButton,
-                    appInformationLabel,
-                    editProfileImageButton,
-                    editProfileCameraIconImageView,
-                    editProfileNameTextField,
-                    profileNameTextFieldUnderLineView,
-                    profileNameCountLabel,
-                    editCompletedButton)
+                    titleLabel,
+                    profileImageButton,
+                    cameraIconImageView,
+                    nameTextField,
+                    underLineView,
+                    numberOfNameCharactersLabel,
+                    completeButton)
     }
     
     private func layout() {
@@ -105,41 +106,41 @@ final class EditProfileView: UIView {
             $0.size.equalTo(42)
         }
         
-        appInformationLabel.snp.makeConstraints {
+        titleLabel.snp.makeConstraints {
             $0.top.equalTo(self.safeAreaLayoutGuide).offset(19)
             $0.leading.equalTo(self.backButton.snp.trailing).offset(83)
         }
         
-        editProfileImageButton.snp.makeConstraints {
-            $0.top.equalTo(self.appInformationLabel.snp.bottom).offset(190)
+        profileImageButton.snp.makeConstraints {
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(190)
             $0.centerX.equalToSuperview()
             $0.size.equalTo(109)
         }
         
-        editProfileCameraIconImageView.snp.makeConstraints {
-            $0.top.equalTo(self.appInformationLabel.snp.bottom).offset(268)
+        cameraIconImageView.snp.makeConstraints {
+            $0.top.equalTo(self.titleLabel.snp.bottom).offset(268)
             $0.leading.equalToSuperview().offset(210)
             $0.size.equalTo(30)
         }
         
-        editProfileNameTextField.snp.makeConstraints {
-            $0.top.equalTo(self.editProfileImageButton.snp.bottom).offset(29)
+        nameTextField.snp.makeConstraints {
+            $0.top.equalTo(self.profileImageButton.snp.bottom).offset(29)
             $0.centerX.equalToSuperview()
         }
         
-        profileNameTextFieldUnderLineView.snp.makeConstraints {
-            $0.top.equalTo(self.editProfileNameTextField.snp.bottom).offset(9)
+        underLineView.snp.makeConstraints {
+            $0.top.equalTo(self.nameTextField.snp.bottom).offset(9)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(205)
             $0.height.equalTo(1)
         }
         
-        profileNameCountLabel.snp.makeConstraints {
-            $0.top.equalTo(self.profileNameTextFieldUnderLineView).offset(9)
-            $0.trailing.equalTo(self.profileNameTextFieldUnderLineView)
+        numberOfNameCharactersLabel.snp.makeConstraints {
+            $0.top.equalTo(self.underLineView).offset(9)
+            $0.trailing.equalTo(self.underLineView)
         }
         
-        editCompletedButton.snp.makeConstraints {
+        completeButton.snp.makeConstraints {
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(27)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(315)

--- a/ZOOC/ZOOC/Presentation/My/View/MyEditProfileView.swift
+++ b/ZOOC/ZOOC/Presentation/My/View/MyEditProfileView.swift
@@ -19,7 +19,7 @@ final class MyEditProfileView: UIView {
     
     public var profileImageButton = UIButton()
     private var cameraIconImageView = UIImageView()
-    public var nameTextField = UITextField()
+    public var nameTextField = BaseTextField()
     public var underLineView = UIView()
     public var numberOfNameCharactersLabel = UILabel()
     public var completeButton = UIButton()

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingChooseFamilyRoleViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingChooseFamilyRoleViewController.swift
@@ -69,7 +69,7 @@ final class OnboardingChooseFamilyRoleViewController: UIViewController{
     @objc private func pushToRegisterProfileImageView() {
         let onboardingRegisterProfileImageViewController = OnboardingRegisterProfileImageViewController()
         let profileName = onboardingChooseFamilyRoleView.chooseFamilyTextField.text!
-        onboardingRegisterProfileImageViewController.dataSend(profileName: profileName)
+        onboardingRegisterProfileImageViewController.dataBind(nickName: profileName)
         self.navigationController?.pushViewController(onboardingRegisterProfileImageViewController, animated: true)
     }
     

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterProfileImageViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterProfileImageViewController.swift
@@ -79,7 +79,7 @@ final class OnboardingRegisterProfileImageViewController: BaseViewController{
                                     photo: image)
         { result in
             print(result)
-            guard let result = self.validateResult(result) as? MyUser else { return }
+            guard let result = self.validateResult(result) as? UserResult else { return }
             self.pushToCompleteProfileView()
         }
     }

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterProfileImageViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterProfileImageViewController.swift
@@ -14,17 +14,18 @@ final class OnboardingRegisterProfileImageViewController: BaseViewController{
     
     //MARK: - Properties
     
-    var isPhoto: Bool = false
-    var image: UIImage?
-    
-    private var profileName: String = ""
+    private var registerMyProfileData = EditProfileRequest(hasPhoto: false)
     private var familyRoleLabel: String = ""
-    private let onboardingRegisterProfileImageView = OnboardingRegisterProfileImageView()
+    
+    
+    //MARK: - UI Components
+    
+    private let rootView = OnboardingRegisterProfileImageView()
     
     //MARK: - Life Cycle
     
     override func loadView() {
-        self.view = onboardingRegisterProfileImageView
+        self.view = rootView
     }
     
     override func viewDidLoad() {
@@ -53,35 +54,35 @@ final class OnboardingRegisterProfileImageViewController: BaseViewController{
         let attributtedString = NSMutableAttributedString(string: familyRoleLabel)
         attributtedString.addAttribute(NSAttributedString.Key.foregroundColor,
                                        value: UIColor.zoocGradientGreen,
-                                       range: (familyRoleLabel as NSString).range(of: "\(profileName)!"))
+                                       range: (familyRoleLabel as NSString).range(of: "\(registerMyProfileData.nickName)!"))
                 
-        onboardingRegisterProfileImageView.registerProfileImageLabel.attributedText = attributtedString
+        rootView.registerProfileImageLabel.attributedText = attributtedString
     }
     
     private func target() {
-        onboardingRegisterProfileImageView.createProfileButton.addTarget(self, action: #selector(createProfileButtonDidTap), for: .touchUpInside)
-        onboardingRegisterProfileImageView.backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
-        onboardingRegisterProfileImageView.registerProfileImageButton.addTarget(self, action: #selector(chooseProfileImage), for: .touchUpInside)
+        rootView.createProfileButton.addTarget(self, action: #selector(createProfileButtonDidTap), for: .touchUpInside)
+        rootView.backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
+        rootView.registerProfileImageButton.addTarget(self, action: #selector(chooseProfileImage), for: .touchUpInside)
     }
     
-    func dataSend(profileName: String) {
-        self.familyRoleLabel = "\(profileName)! \n프로필 사진을 등록할까요?"
-        self.profileName = "\(profileName)"
+    func dataBind(nickName: String) {
+        registerMyProfileData.nickName = nickName
+        familyRoleLabel = "\(nickName)! \n프로필 사진을 등록할까요?"
+    }
+    
+    private func requestRegisterProfileAPI() {
+        MyAPI.shared.patchMyProfile(requset: registerMyProfileData) { result in
+            guard let result = self.validateResult(result) as? UserResult else { return }
+            self.pushToCompleteProfileView()
+        }
     }
     
     //MARK: - Action Method
     
     @objc func createProfileButtonDidTap() {
-        onboardingRegisterProfileImageView.createProfileButton.isEnabled = false
-        onboardingRegisterProfileImageView.createProfileButton.backgroundColor = .zoocGray1
-        MyAPI.shared.patchMyProfile(isPhoto: isPhoto,
-                                    nickName: profileName,
-                                    photo: image)
-        { result in
-            print(result)
-            guard let result = self.validateResult(result) as? UserResult else { return }
-            self.pushToCompleteProfileView()
-        }
+        rootView.createProfileButton.isEnabled = false
+        rootView.createProfileButton.backgroundColor = .zoocGray1
+        requestRegisterProfileAPI()
     }
     
     @objc private func backButtonDidTap() {
@@ -99,9 +100,10 @@ final class OnboardingRegisterProfileImageViewController: BaseViewController{
 extension OnboardingRegisterProfileImageViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate{
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }
-        isPhoto = true
-        self.image = image
-        onboardingRegisterProfileImageView.registerProfileImageButton.setImage(image, for: .normal)
+        
+        registerMyProfileData.hasPhoto = true
+        registerMyProfileData.profileImage = image
+        rootView.registerProfileImageButton.setImage(image, for: .normal)
     }
 }
 


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #91

### ✅ 작업한 내용
- 프로필 편집 뷰 관련 네이밍 싹 변경
- editProfileRequest 모델 생성
- patchProfile API, Service 구조 editProfileRequest로 통일
  - 온보딩에도 연동되어있어서 온보딩쪽도 살짝 수정함.
- 사진보관함, 삭제, 취소 담당하는  GalleryAlertController 객체로 따로 뺌
- 기타 UX 개선 몇가지,,,

### ❗️PR Point
- TextField 마지막 글자수 제대로 입력 안되는 것 같음!

### 📸 스크린샷
- UI 변동사항은 없습니다

closed #91
