### PR TITLE
[Feat] #95 - 소셜로그인 플로우 수정

### DIFF
--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		877E57EE2966AAE6006D82FC /* HomeArchiveListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E57ED2966AAE6006D82FC /* HomeArchiveListCollectionViewCell.swift */; };
 		877E57F02966C046006D82FC /* HomeArchiveModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E57EF2966C046006D82FC /* HomeArchiveModel.swift */; };
 		877E57F22966D13E006D82FC /* HomeDetailArchiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877E57F12966D13E006D82FC /* HomeDetailArchiveViewController.swift */; };
+		8781DE4E29B273FB005ABF23 /* OnboardingFamilyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8781DE4D29B273FB005ABF23 /* OnboardingFamilyResult.swift */; };
 		8782C7DA296857A600C9324B /* KakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = 8782C7D9296857A600C9324B /* KakaoSDKShare */; };
 		8782C7E42968B03500C9324B /* HomePetCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782C7E32968B03500C9324B /* HomePetCollectionViewCell.swift */; };
 		8782C7E62968C0F000C9324B /* HomePetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782C7E52968C0F000C9324B /* HomePetModel.swift */; };
@@ -228,6 +229,7 @@
 		877E57ED2966AAE6006D82FC /* HomeArchiveListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeArchiveListCollectionViewCell.swift; sourceTree = "<group>"; };
 		877E57EF2966C046006D82FC /* HomeArchiveModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeArchiveModel.swift; path = ZOOC/Data/Home/Model/HomeArchiveModel.swift; sourceTree = SOURCE_ROOT; };
 		877E57F12966D13E006D82FC /* HomeDetailArchiveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDetailArchiveViewController.swift; sourceTree = "<group>"; };
+		8781DE4D29B273FB005ABF23 /* OnboardingFamilyResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFamilyResult.swift; sourceTree = "<group>"; };
 		8782C7E32968B03500C9324B /* HomePetCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetCollectionViewCell.swift; sourceTree = "<group>"; };
 		8782C7E52968C0F000C9324B /* HomePetModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePetModel.swift; sourceTree = "<group>"; };
 		8782C7EA296AC58B00C9324B /* HomeArchiveIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeArchiveIndicatorView.swift; sourceTree = "<group>"; };
@@ -789,6 +791,7 @@
 				D2F1936629713FCD00AD87D3 /* OnboardingJWTTokenResult.swift */,
 				D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequest.swift */,
 				D25543A12996B22E0072BF0D /* OnboardingRegisterPetResult.swift */,
+				8781DE4D29B273FB005ABF23 /* OnboardingFamilyResult.swift */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -1079,6 +1082,7 @@
 				D26C68E6296DE61F0088DC9A /* MyRegisterPetTableViewCell.swift in Sources */,
 				D23502F52961A69E00F01101 /* MyView.swift in Sources */,
 				D26C8616296BEF9800AEAF9B /* OnboardingRegisterPetViewController.swift in Sources */,
+				8781DE4E29B273FB005ABF23 /* OnboardingFamilyResult.swift in Sources */,
 				876554A3295848D6006BBDA9 /* BaseViewController.swift in Sources */,
 				4C6B1860296B40C00059840D /* RecordModel.swift in Sources */,
 				D23502F92961F34100F01101 /* MySettingSectionCollectionViewCell.swift in Sources */,

--- a/ZOOC/ZOOC.xcodeproj/project.pbxproj
+++ b/ZOOC/ZOOC.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		D2350309296490A700F01101 /* MyEditProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2350308296490A700F01101 /* MyEditProfileView.swift */; };
 		D235030B2964991700F01101 /* MyEditProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D235030A2964991700F01101 /* MyEditProfileViewController.swift */; };
 		D25543A22996B22E0072BF0D /* OnboardingRegisterPetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25543A12996B22E0072BF0D /* OnboardingRegisterPetResult.swift */; };
-		D25543A4299A239B0072BF0D /* OnboardingRegisterPetRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequestDto.swift */; };
+		D25543A4299A239B0072BF0D /* OnboardingRegisterPetRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequest.swift */; };
 		D26996A42989AB7500025774 /* OnboardingPetRegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26996A32989AB7500025774 /* OnboardingPetRegisterViewModel.swift */; };
 		D26C68E3296DE4F80088DC9A /* MyRegisterPetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C68E2296DE4F80088DC9A /* MyRegisterPetView.swift */; };
 		D26C68E6296DE61F0088DC9A /* MyRegisterPetTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C68E5296DE61F0088DC9A /* MyRegisterPetTableViewCell.swift */; };
@@ -156,7 +156,7 @@
 		D26C8616296BEF9800AEAF9B /* OnboardingRegisterPetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C8615296BEF9800AEAF9B /* OnboardingRegisterPetViewController.swift */; };
 		D26C861A296C0FC800AEAF9B /* OnboardingPetRegisterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C8619296C0FC800AEAF9B /* OnboardingPetRegisterModel.swift */; };
 		D26C861C296C1A8A00AEAF9B /* OnboardingRegisterPetTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26C861B296C1A8A00AEAF9B /* OnboardingRegisterPetTableFooterView.swift */; };
-		D2779742299F76FD008A237D /* OnboardingAppleSocailLoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2779741299F76FD008A237D /* OnboardingAppleSocailLoginRequestDto.swift */; };
+		D2779742299F76FD008A237D /* OnboardingAppleSocialLoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2779741299F76FD008A237D /* OnboardingAppleSocialLoginRequest.swift */; };
 		D27D9560296C9F5D0097CD03 /* OnboardingInviteFamilyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27D955F296C9F5D0097CD03 /* OnboardingInviteFamilyView.swift */; };
 		D27D9562296CA4640097CD03 /* OnboardingInviteFamilyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27D9561296CA4640097CD03 /* OnboardingInviteFamilyViewController.swift */; };
 		D27D9564296CA9720097CD03 /* OnboardingInviteCompletedFamilyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D27D9563296CA9720097CD03 /* OnboardingInviteCompletedFamilyView.swift */; };
@@ -169,8 +169,8 @@
 		D2DD45C7297D9612001722A1 /* BaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2DD45C6297D9612001722A1 /* BaseButton.swift */; };
 		D2F193612970B3FB00AD87D3 /* HomeNoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F193602970B3FB00AD87D3 /* HomeNoticeModel.swift */; };
 		D2F193632970B95E00AD87D3 /* HomeNoticeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F193622970B95E00AD87D3 /* HomeNoticeResult.swift */; };
-		D2F193652970E72500AD87D3 /* OnboardingRegisterUserRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequestDto.swift */; };
-		D2F1936729713FCD00AD87D3 /* OnboardingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1936629713FCD00AD87D3 /* OnboardingResult.swift */; };
+		D2F193652970E72500AD87D3 /* OnboardingRegisterUserRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequest.swift */; };
+		D2F1936729713FCD00AD87D3 /* OnboardingJWTTokenResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F1936629713FCD00AD87D3 /* OnboardingJWTTokenResult.swift */; };
 		D2F98F9D2967154D00CC82DE /* ZoocAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F98F9C2967154D00CC82DE /* ZoocAlertViewController.swift */; };
 		D2F98F9F29676E3300CC82DE /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F98F9E29676E3300CC82DE /* UINavigationController+.swift */; };
 		D2F98FA5296782AE00CC82DE /* MyProfileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F98FA4296782AE00CC82DE /* MyProfileModel.swift */; };
@@ -277,7 +277,7 @@
 		D2350308296490A700F01101 /* MyEditProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyEditProfileView.swift; sourceTree = "<group>"; };
 		D235030A2964991700F01101 /* MyEditProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyEditProfileViewController.swift; sourceTree = "<group>"; };
 		D25543A12996B22E0072BF0D /* OnboardingRegisterPetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterPetResult.swift; sourceTree = "<group>"; };
-		D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterPetRequestDto.swift; sourceTree = "<group>"; };
+		D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterPetRequest.swift; sourceTree = "<group>"; };
 		D26996A32989AB7500025774 /* OnboardingPetRegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPetRegisterViewModel.swift; sourceTree = "<group>"; };
 		D26C68E2296DE4F80088DC9A /* MyRegisterPetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegisterPetView.swift; sourceTree = "<group>"; };
 		D26C68E5296DE61F0088DC9A /* MyRegisterPetTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRegisterPetTableViewCell.swift; sourceTree = "<group>"; };
@@ -321,7 +321,7 @@
 		D26C8615296BEF9800AEAF9B /* OnboardingRegisterPetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterPetViewController.swift; sourceTree = "<group>"; };
 		D26C8619296C0FC800AEAF9B /* OnboardingPetRegisterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPetRegisterModel.swift; sourceTree = "<group>"; };
 		D26C861B296C1A8A00AEAF9B /* OnboardingRegisterPetTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterPetTableFooterView.swift; sourceTree = "<group>"; };
-		D2779741299F76FD008A237D /* OnboardingAppleSocailLoginRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAppleSocailLoginRequestDto.swift; sourceTree = "<group>"; };
+		D2779741299F76FD008A237D /* OnboardingAppleSocialLoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAppleSocialLoginRequest.swift; sourceTree = "<group>"; };
 		D27D955F296C9F5D0097CD03 /* OnboardingInviteFamilyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteFamilyView.swift; sourceTree = "<group>"; };
 		D27D9561296CA4640097CD03 /* OnboardingInviteFamilyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteFamilyViewController.swift; sourceTree = "<group>"; };
 		D27D9563296CA9720097CD03 /* OnboardingInviteCompletedFamilyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInviteCompletedFamilyView.swift; sourceTree = "<group>"; };
@@ -335,8 +335,8 @@
 		D2DD45C6297D9612001722A1 /* BaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseButton.swift; sourceTree = "<group>"; };
 		D2F193602970B3FB00AD87D3 /* HomeNoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNoticeModel.swift; sourceTree = "<group>"; };
 		D2F193622970B95E00AD87D3 /* HomeNoticeResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNoticeResult.swift; sourceTree = "<group>"; };
-		D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterUserRequestDto.swift; sourceTree = "<group>"; };
-		D2F1936629713FCD00AD87D3 /* OnboardingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingResult.swift; sourceTree = "<group>"; };
+		D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRegisterUserRequest.swift; sourceTree = "<group>"; };
+		D2F1936629713FCD00AD87D3 /* OnboardingJWTTokenResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingJWTTokenResult.swift; sourceTree = "<group>"; };
 		D2F98F9C2967154D00CC82DE /* ZoocAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoocAlertViewController.swift; sourceTree = "<group>"; };
 		D2F98F9E29676E3300CC82DE /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		D2F98FA4296782AE00CC82DE /* MyProfileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileModel.swift; sourceTree = "<group>"; };
@@ -784,11 +784,11 @@
 			isa = PBXGroup;
 			children = (
 				4C8A7C32297063F400783979 /* OnboardingInviteResult.swift */,
-				D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequestDto.swift */,
-				D2F1936629713FCD00AD87D3 /* OnboardingResult.swift */,
+				D2F193642970E72500AD87D3 /* OnboardingRegisterUserRequest.swift */,
+				D2779741299F76FD008A237D /* OnboardingAppleSocialLoginRequest.swift */,
+				D2F1936629713FCD00AD87D3 /* OnboardingJWTTokenResult.swift */,
+				D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequest.swift */,
 				D25543A12996B22E0072BF0D /* OnboardingRegisterPetResult.swift */,
-				D25543A3299A239B0072BF0D /* OnboardingRegisterPetRequestDto.swift */,
-				D2779741299F76FD008A237D /* OnboardingAppleSocailLoginRequestDto.swift */,
 			);
 			path = APIModel;
 			sourceTree = "<group>";
@@ -1047,7 +1047,7 @@
 				D26C68E8296DE65E0088DC9A /* MyRegisterPetViewController.swift in Sources */,
 				8764831D2952368100F74882 /* UIView+.swift in Sources */,
 				871EA33E296F529C00D0E8CC /* UIImageView+.swift in Sources */,
-				D2F1936729713FCD00AD87D3 /* OnboardingResult.swift in Sources */,
+				D2F1936729713FCD00AD87D3 /* OnboardingJWTTokenResult.swift in Sources */,
 				D26C8600296B27B100AEAF9B /* OnboardingCompleteProfileView.swift in Sources */,
 				D27D95D5296DDF4F0097CD03 /* MyFamilyCollectionViewCell.swift in Sources */,
 				8764832B295238EB00F74882 /* UITextField+.swift in Sources */,
@@ -1108,7 +1108,7 @@
 				4C6B186C296CB8730059840D /* RecordCompleteViewController.swift in Sources */,
 				4C6B1864296B6C600059840D /* RecordRegisterModel.swift in Sources */,
 				87A76AA1295F6EA90096F669 /* OnboardingAPI.swift in Sources */,
-				D25543A4299A239B0072BF0D /* OnboardingRegisterPetRequestDto.swift in Sources */,
+				D25543A4299A239B0072BF0D /* OnboardingRegisterPetRequest.swift in Sources */,
 				D26C85F029693C8500AEAF9B /* OnboardingWelcomeView.swift in Sources */,
 				8731C4B429A94A6900006743 /* HomeEmojiCommentRequest.swift in Sources */,
 				8731C4B029A93EF500006743 /* EmojiModel.swift in Sources */,
@@ -1124,7 +1124,7 @@
 				D27D95D7296DE0E30097CD03 /* MyFamilySectionCollectionViewCell.swift in Sources */,
 				87A76AA9295F6ED70096F669 /* MyAPI.swift in Sources */,
 				D26C85D1296869DD00AEAF9B /* UICollectionReusableView+.swift in Sources */,
-				D2779742299F76FD008A237D /* OnboardingAppleSocailLoginRequestDto.swift in Sources */,
+				D2779742299F76FD008A237D /* OnboardingAppleSocialLoginRequest.swift in Sources */,
 				8764831B2952367400F74882 /* UIViewController+.swift in Sources */,
 				87A76AC82960430A0096F669 /* MoyaLoggerPlugin.swift in Sources */,
 				D26C85EE2968D51F00AEAF9B /* UITableViewHeaderFooterView+.swift in Sources */,
@@ -1175,7 +1175,7 @@
 				D26C68EC296DE7B60088DC9A /* MyPetRegisterModel.swift in Sources */,
 				871EA342296F73DE00D0E8CC /* User.swift in Sources */,
 				87C109252971A5B40086466F /* HomeCommentRequest.swift in Sources */,
-				D2F193652970E72500AD87D3 /* OnboardingRegisterUserRequestDto.swift in Sources */,
+				D2F193652970E72500AD87D3 /* OnboardingRegisterUserRequest.swift in Sources */,
 				8782C7F5296DB7FC00C9324B /* HomeDetailArchiveCommentTextField.swift in Sources */,
 				871EA344296F768100D0E8CC /* HomeArchiveResult.swift in Sources */,
 				87D5AF622960CFE500CA7F12 /* HomeGuideCollectionViewCell.swift in Sources */,

--- a/ZOOC/ZOOC/Data/Common/Model/User.swift
+++ b/ZOOC/ZOOC/Data/Common/Model/User.swift
@@ -8,9 +8,11 @@
 import Foundation
 
 struct User {
-    static var id: String = "1"
-    static var familyID: String = "1"
-    static var jwtToken: String = ""
+    static var shared = User()
+    private init() {}
     
+    var id: String = "1"
+    var familyID: String = "1"
+    var jwtToken: String = ""
 }
 

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingAppleSocialLoginRequest.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingAppleSocialLoginRequest.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct OnboardingAppleSocailLoginRequestDto: Codable {
+struct OnboardingAppleSocialLoginRequest: Codable {
     let identityTokenString: String
 }

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingFamilyResult.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingFamilyResult.swift
@@ -1,0 +1,14 @@
+//
+//  OnboardingFamilyResult.swift
+//  ZOOC
+//
+//  Created by 장석우 on 2023/03/04.
+//
+
+import Foundation
+
+struct OnboardingFamilyResult: Codable {
+    let id: Int
+    let code: String
+}
+

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingJWTTokenResult.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingJWTTokenResult.swift
@@ -11,8 +11,5 @@ import Foundation
 
 struct OnboardingJWTTokenResult: Codable {
     let jwtToken: String
-    
-    enum CodingKeys: String, CodingKey {
-        case jwtToken
-    }
+    let isExistedUser: Bool
 }

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingJWTTokenResult.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingJWTTokenResult.swift
@@ -9,16 +9,7 @@ import Foundation
 
 // MARK: - MyResult
 
-struct OnboardingResult: Codable {
-    let status: Int
-    let success: Bool
-    let message: String
-    let data: OnboardingTokenData
-}
-
-// MARK: - DataClass
-
-struct OnboardingTokenData: Codable {
+struct OnboardingJWTTokenResult: Codable {
     let jwtToken: String
     
     enum CodingKeys: String, CodingKey {

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingRegisterPetRequest.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingRegisterPetRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct OnboardingRegisterPetRequestDto: Codable {
+struct OnboardingRegisterPetRequest: Codable {
     let petNames: [String]
     let files: [Data?]
     let isPetPhotos: [Bool]

--- a/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingRegisterUserRequest.swift
+++ b/ZOOC/ZOOC/Data/Onboarding/APIModel/OnboardingRegisterUserRequest.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct OnboardingRegisterUserRequestDto: Codable {
+struct OnboardingRegisterUserRequest: Codable {
     let code: String
 }

--- a/ZOOC/ZOOC/Network/Base/APIConstants.swift
+++ b/ZOOC/ZOOC/Network/Base/APIConstants.swift
@@ -22,8 +22,8 @@ struct APIConstants{
 extension APIConstants{
     static let noTokenHeader = [contentType: applicationJSON]
     static let hasTokenHeader = [contentType: applicationJSON,
-                                       auth : User.jwtToken]
+                                       auth : User.shared.jwtToken]
     static let multipartHeader = [contentType: multipartFormData,
-                                        auth : User.jwtToken]
+                                        auth : User.shared.jwtToken]
     
 }

--- a/ZOOC/ZOOC/Network/Base/APIConstants.swift
+++ b/ZOOC/ZOOC/Network/Base/APIConstants.swift
@@ -22,8 +22,8 @@ struct APIConstants{
 extension APIConstants{
     static let noTokenHeader = [contentType: applicationJSON]
     static let hasTokenHeader = [contentType: applicationJSON,
-                                       auth : accessToken]
+                                       auth : User.jwtToken]
     static let multipartHeader = [contentType: multipartFormData,
-                                        auth : accessToken]
+                                        auth : User.jwtToken]
     
 }

--- a/ZOOC/ZOOC/Network/Home/HomeAPI.swift
+++ b/ZOOC/ZOOC/Network/Home/HomeAPI.swift
@@ -33,7 +33,7 @@ extension HomeAPI{
     }
     
     func getTotalArchive(petID: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        homeProvider.request(.getTotalArchive(familyID: User.familyID, petID: petID)) { (result) in
+        homeProvider.request(.getTotalArchive(familyID: User.shared.familyID, petID: petID)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: [HomeArchiveResult].self,
                                 completion: completion)
@@ -41,7 +41,7 @@ extension HomeAPI{
     }
     
     func getDetailArchive(recordID: String, completion: @escaping (NetworkResult<Any>) -> Void) {
-        homeProvider.request(.getDetailArchive(familyID: User.familyID, recordID: recordID)) { (result) in
+        homeProvider.request(.getDetailArchive(familyID: User.shared.familyID, recordID: recordID)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: HomeDetailArchiveResult.self,
                                 completion: completion)
@@ -49,7 +49,7 @@ extension HomeAPI{
     } //아마 사용안함
     
     func getDetailPetArchive(recordID: String, petID: String ,completion: @escaping (NetworkResult<Any>) -> Void) {
-        homeProvider.request(.getDetailPetArchive(familyID: User.familyID, recordID: recordID, petID: petID)) { (result) in
+        homeProvider.request(.getDetailPetArchive(familyID: User.shared.familyID, recordID: recordID, petID: petID)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: HomeDetailArchiveResult.self,
                                 completion: completion)

--- a/ZOOC/ZOOC/Network/Onboarding/OnboardingAPI.swift
+++ b/ZOOC/ZOOC/Network/Onboarding/OnboardingAPI.swift
@@ -15,8 +15,10 @@ class OnboardingAPI: BaseAPI {
 
 extension OnboardingAPI {
     public func getInviteCode(familyID: String ,completion: @escaping (NetworkResult<Any>) -> Void) {
-        onboardingProvider.request(.getInviteCode(familyId: familyID)) {
-            (result) in self.disposeNetwork(result, dataModel: OnboardingInviteResult.self, completion: completion)
+        onboardingProvider.request(.getInviteCode(familyId: familyID)) { (result) in
+            self.disposeNetwork(result,
+                                dataModel: OnboardingInviteResult.self,
+                                completion: completion)
         }
     }
     
@@ -29,8 +31,7 @@ extension OnboardingAPI {
     }
     
     public func postRegisterPet(request: OnboardingRegisterPetRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
-        onboardingProvider.request(.postRegisterPet(request)) {
-            (result) in
+        onboardingProvider.request(.postRegisterPet(request)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: [OnboardingRegisterPetResult].self,
                                 completion: completion)
@@ -44,6 +45,7 @@ extension OnboardingAPI {
                                 completion: completion)
         }
     }
+    
     public func postAppleSocialLogin(request: OnboardingAppleSocialLoginRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
         onboardingProvider.request(.postAppleSocialLogin(request)) { (result) in
             self.disposeNetwork(result,
@@ -51,4 +53,14 @@ extension OnboardingAPI {
                                 completion: completion)
         }
     }
+    
+    public func getFamily(completion: @escaping (NetworkResult<Any>) -> Void) {
+        onboardingProvider.request(.getFamily) {(result) in
+            self.disposeNetwork(result,
+                                dataModel: [OnboardingFamilyResult].self,
+                                completion: completion)
+        }
+    }
+    
+    
 }

--- a/ZOOC/ZOOC/Network/Onboarding/OnboardingAPI.swift
+++ b/ZOOC/ZOOC/Network/Onboarding/OnboardingAPI.swift
@@ -20,16 +20,16 @@ extension OnboardingAPI {
         }
     }
     
-    public func registerUser(param: OnboardingRegisterUserRequestDto, completion: @escaping (NetworkResult<Any>) -> Void) {
-        onboardingProvider.request(.postRegisterUser(param: param)) { (result) in
+    public func postRegisterUser(requset: OnboardingRegisterUserRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
+        onboardingProvider.request(.postRegisterUser(requset)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: SimpleResponse.self,
                                 completion: completion)
         }
     }
     
-    public func registerPet(param: OnboardingRegisterPetRequestDto, completion: @escaping (NetworkResult<Any>) -> Void) {
-        onboardingProvider.request(.postRegisterPet(param: param)) {
+    public func postRegisterPet(request: OnboardingRegisterPetRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
+        onboardingProvider.request(.postRegisterPet(request)) {
             (result) in
             self.disposeNetwork(result,
                                 dataModel: [OnboardingRegisterPetResult].self,
@@ -40,14 +40,14 @@ extension OnboardingAPI {
     public func postKakaoSocialLogin(accessToken: String, completion: @escaping (NetworkResult<Any>) -> Void) {
         onboardingProvider.request(.postKakaoSocialLogin(accessToken: accessToken)) { (result) in
             self.disposeNetwork(result,
-                                dataModel: OnboardingTokenData.self,
+                                dataModel: OnboardingJWTTokenResult.self,
                                 completion: completion)
         }
     }
-    public func postAppleSocialLogin(param: OnboardingAppleSocailLoginRequestDto, completion: @escaping (NetworkResult<Any>) -> Void) {
-        onboardingProvider.request(.postAppleSocialLogin(param: param)) { (result) in
+    public func postAppleSocialLogin(request: OnboardingAppleSocialLoginRequest, completion: @escaping (NetworkResult<Any>) -> Void) {
+        onboardingProvider.request(.postAppleSocialLogin(request)) { (result) in
             self.disposeNetwork(result,
-                                dataModel: OnboardingTokenData.self,
+                                dataModel: OnboardingJWTTokenResult.self,
                                 completion: completion)
         }
     }

--- a/ZOOC/ZOOC/Network/Onboarding/OnboardingService.swift
+++ b/ZOOC/ZOOC/Network/Onboarding/OnboardingService.swift
@@ -12,10 +12,10 @@ import UIKit
 
 enum OnboardingService {
     case getInviteCode(familyId: String)
-    case postRegisterUser(param: OnboardingRegisterUserRequestDto)
-    case postRegisterPet(param: OnboardingRegisterPetRequestDto)
+    case postRegisterUser(_ request: OnboardingRegisterUserRequest)
+    case postRegisterPet(_ request: OnboardingRegisterPetRequest)
     case postKakaoSocialLogin(accessToken: String)
-    case postAppleSocialLogin(param: OnboardingAppleSocailLoginRequestDto)
+    case postAppleSocialLogin(_ request: OnboardingAppleSocialLoginRequest)
 }
 
 extension OnboardingService: BaseTargetType {
@@ -25,8 +25,8 @@ extension OnboardingService: BaseTargetType {
             return URLs.getInviteCode.replacingOccurrences(of: "{familyId}", with: familyId)
         case .postRegisterUser:
             return URLs.registerUser
-        case .postRegisterPet(param: _):
-            return URLs.registerPet.replacingOccurrences(of: "{familyId}", with: "1")
+        case .postRegisterPet(let request):
+            return URLs.registerPet.replacingOccurrences(of: "{familyId}", with: "1") //TODO: 1로 고정되어있음 꽤 큰 작업이 될지도
         case .postKakaoSocialLogin:
             return URLs.kakaoLogin
         case .postAppleSocialLogin:
@@ -38,9 +38,9 @@ extension OnboardingService: BaseTargetType {
         switch self {
         case .getInviteCode:
             return .get
-        case .postRegisterUser(param: _):
+        case .postRegisterUser:
             return .post
-        case .postRegisterPet(param: _):
+        case .postRegisterPet:
             return .post
         case .postKakaoSocialLogin:
             return .post
@@ -54,13 +54,13 @@ extension OnboardingService: BaseTargetType {
         switch self {
         case .getInviteCode:
             return .requestPlain
-        case .postRegisterUser(param: let param):
+        case .postRegisterUser(let param):
             return .requestJSONEncodable(param)
         case .postKakaoSocialLogin:
             return .requestPlain
-        case .postAppleSocialLogin(param: let param):
+        case .postAppleSocialLogin(let param):
             return .requestJSONEncodable(param)
-        case .postRegisterPet(param: let param):
+        case .postRegisterPet(let param):
             var multipartFormDatas: [MultipartFormData] = []
             
             for name in param.petNames {

--- a/ZOOC/ZOOC/Network/Onboarding/OnboardingService.swift
+++ b/ZOOC/ZOOC/Network/Onboarding/OnboardingService.swift
@@ -11,6 +11,7 @@ import Moya
 import UIKit
 
 enum OnboardingService {
+    case getFamily
     case getInviteCode(familyId: String)
     case postRegisterUser(_ request: OnboardingRegisterUserRequest)
     case postRegisterPet(_ request: OnboardingRegisterPetRequest)
@@ -26,11 +27,13 @@ extension OnboardingService: BaseTargetType {
         case .postRegisterUser:
             return URLs.registerUser
         case .postRegisterPet(let request):
-            return URLs.registerPet.replacingOccurrences(of: "{familyId}", with: "1") //TODO: 1로 고정되어있음 꽤 큰 작업이 될지도
+            return URLs.registerPet.replacingOccurrences(of: "{familyId}", with: User.shared.familyID) //TODO: 1로 고정되어있음 꽤 큰 작업이 될지도
         case .postKakaoSocialLogin:
             return URLs.kakaoLogin
         case .postAppleSocialLogin:
             return URLs.appleLogin
+        case .getFamily:
+            return URLs.getFamily
         }
     }
     
@@ -46,6 +49,8 @@ extension OnboardingService: BaseTargetType {
             return .post
         case .postAppleSocialLogin:
             return .post
+        case .getFamily:
+            return .get
         }
     }
     
@@ -85,7 +90,10 @@ extension OnboardingService: BaseTargetType {
             }
 
             return .uploadMultipart(multipartFormDatas)
+        case .getFamily:
+            return .requestPlain
         }
+        
     }
     
     var headers: [String : String]?{
@@ -102,6 +110,8 @@ extension OnboardingService: BaseTargetType {
                     APIConstants.auth : accessToken]
         case .postAppleSocialLogin(param: _):
             return APIConstants.noTokenHeader
+        case .getFamily:
+            return APIConstants.hasTokenHeader
         }
     }
 }

--- a/ZOOC/ZOOC/Network/Record/RecordAPI.swift
+++ b/ZOOC/ZOOC/Network/Record/RecordAPI.swift
@@ -16,7 +16,7 @@ class RecordAPI: BaseAPI {
 
 extension RecordAPI{
     func getTotalPet(completion: @escaping (NetworkResult<Any>) -> Void) {
-        recordProvider.request(.getTotalPet(familyID: User.familyID)) { (result) in
+        recordProvider.request(.getTotalPet(familyID: User.shared.familyID)) { (result) in
             self.disposeNetwork(result,
                                 dataModel: [RecordPetResult].self,
                                 completion: completion)
@@ -24,7 +24,7 @@ extension RecordAPI{
     }
     
     func postRecord(photo: UIImage, content: String, pets: [Int], completion: @escaping (NetworkResult<Any>) -> Void){
-        recordProvider.request(.postRecord(familyID: User.familyID,
+        recordProvider.request(.postRecord(familyID: User.shared.familyID,
                                            photo: photo,
                                            content: content,
                                            pets: pets))

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeViewController.swift
@@ -138,7 +138,7 @@ final class HomeViewController : BaseViewController {
     //MARK: - Network
     
     private func requestMissionAPI() {
-        HomeAPI.shared.getMission(familyID: User.familyID) { result in
+        HomeAPI.shared.getMission(familyID: User.shared.familyID) { result in
             
             guard let result = self.validateResult(result) as? [HomeMissionResult] else { return }
             
@@ -147,7 +147,7 @@ final class HomeViewController : BaseViewController {
     }
 
     private func requestTotalPetAPI() {
-        HomeAPI.shared.getTotalPet(familyID: User.familyID) { result in
+        HomeAPI.shared.getTotalPet(familyID: User.shared.familyID) { result in
             
             guard let result = self.validateResult(result) as? [HomePetResult] else { return }
             

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingInviteFamilyViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingInviteFamilyViewController.swift
@@ -100,7 +100,7 @@ private extension OnboardingInviteFamilyViewController {
     }
     
     func getInviteCode() {
-        OnboardingAPI.shared.getInviteCode(familyID: User.familyID) { result in
+        OnboardingAPI.shared.getInviteCode(familyID: User.shared.familyID) { result in
             guard let result = self.validateResult(result) as? OnboardingInviteResult else { return }
             let code = result.code
             self.invitedCode = code

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
@@ -113,7 +113,6 @@ private extension OnboardingLoginViewController {
         OnboardingAPI.shared.postAppleSocialLogin(request: OnboardingAppleSocialLoginRequest(identityTokenString: identityTokenString)) { result in
             guard let result = self.validateResult(result) as? OnboardingJWTTokenResult else { return }
             User.shared.jwtToken = result.jwtToken
-            print("드디어 받아온 jwt 토큰 \(User.shared.jwtToken)")
             
             if result.isExistedUser{
                 self.requestFamilyAPI()
@@ -129,9 +128,8 @@ private extension OnboardingLoginViewController {
             guard let result = self.validateResult(result) as? [OnboardingFamilyResult] else { return }
             
             if result.count != 0 {
-                guard let familyID = result[0].id as? String else { return }
+                let familyID = String(result[0].id)
                 User.shared.familyID = familyID
-                print(User.shared.familyID)
                 self.changeRootViewController(ZoocTabBarController())
             } else {
                 self.pushToAgreementView()

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
@@ -89,7 +89,13 @@ private extension OnboardingLoginViewController {
         OnboardingAPI.shared.postKakaoSocialLogin(accessToken: "Bearer \(oauthToken.accessToken)") { result in
             guard let result = self.validateResult(result) as? OnboardingJWTTokenResult else { return }
             User.jwtToken = result.jwtToken
-            self.pushToAgreementView()
+            
+            if result.isExistedUser{
+                self.changeRootViewController(ZoocTabBarController())
+            } else {
+                self.pushToAgreementView()
+            }
+            
         }
     }
     
@@ -108,7 +114,13 @@ private extension OnboardingLoginViewController {
             guard let result = self.validateResult(result) as? OnboardingJWTTokenResult else { return }
             User.jwtToken = result.jwtToken
             print("드디어 받아온 jwt 토큰 \(User.jwtToken)")
-            self.pushToAgreementView()
+            
+            if result.isExistedUser{
+                self.changeRootViewController(ZoocTabBarController())
+            } else {
+                self.pushToAgreementView()
+            }
+            
         }
     }
 }

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
@@ -88,10 +88,10 @@ private extension OnboardingLoginViewController {
     private func requestZOOCKaKaoLoginAPI(_ oauthToken: OAuthToken) {
         OnboardingAPI.shared.postKakaoSocialLogin(accessToken: "Bearer \(oauthToken.accessToken)") { result in
             guard let result = self.validateResult(result) as? OnboardingJWTTokenResult else { return }
-            User.jwtToken = result.jwtToken
+            User.shared.jwtToken = result.jwtToken
             
             if result.isExistedUser{
-                self.changeRootViewController(ZoocTabBarController())
+                self.requestFamilyAPI()
             } else {
                 self.pushToAgreementView()
             }
@@ -112,15 +112,30 @@ private extension OnboardingLoginViewController {
     private func requestZOOCAppleSocialLoginAPI(_ identityTokenString: String) {
         OnboardingAPI.shared.postAppleSocialLogin(request: OnboardingAppleSocialLoginRequest(identityTokenString: identityTokenString)) { result in
             guard let result = self.validateResult(result) as? OnboardingJWTTokenResult else { return }
-            User.jwtToken = result.jwtToken
-            print("드디어 받아온 jwt 토큰 \(User.jwtToken)")
+            User.shared.jwtToken = result.jwtToken
+            print("드디어 받아온 jwt 토큰 \(User.shared.jwtToken)")
             
             if result.isExistedUser{
-                self.changeRootViewController(ZoocTabBarController())
+                self.requestFamilyAPI()
             } else {
                 self.pushToAgreementView()
             }
             
+        }
+    }
+    
+    private func requestFamilyAPI() {
+        OnboardingAPI.shared.getFamily { result in
+            guard let result = self.validateResult(result) as? [OnboardingFamilyResult] else { return }
+            
+            if result.count != 0 {
+                guard let familyID = result[0].id as? String else { return }
+                User.shared.familyID = familyID
+                print(User.shared.familyID)
+                self.changeRootViewController(ZoocTabBarController())
+            } else {
+                self.pushToAgreementView()
+            }
         }
     }
 }

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingParticipateViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingParticipateViewController.swift
@@ -54,8 +54,8 @@ final class OnboardingParticipateViewController: BaseViewController {
 extension OnboardingParticipateViewController {
     func registerUser() {
         guard let code = onboardingParticipateView.familyCodeTextField.text else { return }
-        let param = OnboardingRegisterUserRequestDto(code: code)
-        OnboardingAPI.shared.registerUser(param: param) { result in
+        let param = OnboardingRegisterUserRequest(code: code)
+        OnboardingAPI.shared.postRegisterUser(requset: param) { result in
             guard let result = self.validateResult(result) as? SimpleResponse else { return }
             
             print(result)

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterPetViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingRegisterPetViewController.swift
@@ -83,8 +83,8 @@ final class OnboardingRegisterPetViewController: BaseViewController{
             isPhotos.append(isPhoto)
         }
         
-        OnboardingAPI.shared.registerPet(
-            param: OnboardingRegisterPetRequestDto(petNames: names, files: photos, isPetPhotos: isPhotos)
+        OnboardingAPI.shared.postRegisterPet(
+            request: OnboardingRegisterPetRequest(petNames: names, files: photos, isPetPhotos: isPhotos)
         ) { result in
             guard let result = self.validateResult(result) as? [OnboardingRegisterPetResult] else {
                 return


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #95 

### ✅ 작업한 내용
-  Auth 관련 API 네이밍 변경
- Onboarding Auth 관련 함수 구조 변경 
- **API 호출 후 결과와 상관없이 화면 이동하는 오류 해결**
- JWT mockData 사용이 아닌 실제 서버에서 받는 jwt 토큰 사용하도록 통일
- 로그인 시 기존유저, 신규 유저에 따라 화면 분기 처리 (socialLoginAPI 수정사항 반영)
  - 신규유저: 소셜로그인 -> 온보딩뷰 -> ZOOC 메인화면
  - 기존유저: 소셜로그인 -> ZOOC 메인화면
- 기존유저일 시 가족 정보 유무에 따른 분기 처리 (getFamily API 추가)
  - 가족 무: 소셜로그인 -> 온보딩뷰 -> ZOOC 메인화면
  - 가족 유: 소셜로그인 -> ZOOC 메인 화면
- User 객체 싱글톤으로 수정

### ❗️PR Point
- <API 호출 후 결과와 상관없이 화면 이동하는 오류> 해결 중요합니다 꼭 봐주세용
- jwt토큰 현재 User 객체에서 관리합니당
- 자동로그인 구현시 jwt토큰을 휴대폰 DB(UserDefault or Keychain)에서 받아오면 User.shared.jwtToken 에서 값 넣어주세여.

### 📸 스크린샷
UI 변동사항 없음

closed #95 
