### PR TITLE
[Feat] #110 - 로그아웃 FCM API 연동

### DIFF
--- a/ZOOC/ZOOC/Application/SceneDelegate.swift
+++ b/ZOOC/ZOOC/Application/SceneDelegate.swift
@@ -28,9 +28,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let onboardingNVC = UINavigationController(rootViewController: OnboardingLoginViewController())
         onboardingNVC.setNavigationBarHidden(true, animated: true)
         
-        //홈 Flow 부터
-        let zoocTabBarController = ZoocTabBarController()
-        
         window?.rootViewController = onboardingNVC //
         self.window?.backgroundColor = .white
         window?.makeKeyAndVisible()

--- a/ZOOC/ZOOC/Data/User.swift
+++ b/ZOOC/ZOOC/Data/User.swift
@@ -11,9 +11,16 @@ struct User {
     static var shared = User()
     private init() {}
     
-    var id: String = "1"
-    var familyID: String = "1"
+    var id: String = ""
+    var familyID: String = ""
     var jwtToken: String = ""
     var fcmToken: String = ""
+    
+    public mutating func clearData() {
+        id = ""
+        familyID = ""
+        jwtToken = ""
+    }
 }
+
 

--- a/ZOOC/ZOOC/Global/Constant/URLs.swift
+++ b/ZOOC/ZOOC/Global/Constant/URLs.swift
@@ -27,6 +27,7 @@ public enum URLs{
     static let signUp = "/user/create?code={code}"
     static let deleteUser = "/user"
     static let fcmToken = "/user/fcm_token"
+    static let logout = "/user/signout"
     
     //MARK: - Record
     static let getMission = "/record/mission/{familyId}"

--- a/ZOOC/ZOOC/Network/My/MyAPI.swift
+++ b/ZOOC/ZOOC/Network/My/MyAPI.swift
@@ -32,8 +32,6 @@ extension MyAPI{
         }
     }
     
-    
-    
     func deleteAccount(completion: @escaping (NetworkResult<Any>) -> Void) {
         myProvider.request(.deleteAccount) { (result) in
             self.disposeNetwork(result,
@@ -47,6 +45,14 @@ extension MyAPI{
             (result) in
             self.disposeNetwork(result,
                                 dataModel: [MyRegisterPetResult].self,
+                                completion: completion)
+        }
+    }
+    
+    public func logout(completion: @escaping (NetworkResult<Any>) -> Void) {
+        myProvider.request(.logout) { result in
+            self.disposeNetwork(result,
+                                dataModel: VoidResult.self,
                                 completion: completion)
         }
     }

--- a/ZOOC/ZOOC/Network/My/MyService.swift
+++ b/ZOOC/ZOOC/Network/My/MyService.swift
@@ -14,6 +14,7 @@ enum MyService {
     case patchUserProfile(_ request: EditProfileRequest)
     case deleteAccount
     case postRegisterPet(param: MyRegisterPetRequestDto)
+    case logout
 }
 
 extension MyService: BaseTargetType {
@@ -27,6 +28,8 @@ extension MyService: BaseTargetType {
             return "/user"
         case .postRegisterPet(param: _):
             return URLs.registerPet.replacingOccurrences(of: "{familyId}", with: User.shared.familyID) //TODO: 이 위치가 맞을까..
+        case .logout:
+            return URLs.logout
         }
     }
     
@@ -40,6 +43,8 @@ extension MyService: BaseTargetType {
             return .delete
         case .postRegisterPet(param: _):
             return .post
+        case .logout:
+            return .patch
         }
     }
     
@@ -99,6 +104,10 @@ extension MyService: BaseTargetType {
             }
 
             return .uploadMultipart(multipartFormDatas)
+            
+        case .logout:
+            return .requestParameters(parameters: ["fcmToken": User.shared.fcmToken],
+                                      encoding: JSONEncoding.default)
         }
     }
     
@@ -112,6 +121,8 @@ extension MyService: BaseTargetType {
             return APIConstants.hasTokenHeader
         case .postRegisterPet(param: _):
             return APIConstants.multipartHeader
+        case .logout:
+            return APIConstants.hasTokenHeader
         }
         
     }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyEditProfileViewController.swift
@@ -146,7 +146,7 @@ extension MyEditProfileViewController {
     
     private func popToMyProfileView() {
         guard let beforeVC = self.navigationController?.previousViewController as? MyViewController else { return }
-        beforeVC.getMyPageAPI()
+        beforeVC.requestMyPageAPI()
         self.navigationController?.popViewController(animated: true)
     }
 }

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
@@ -67,10 +67,19 @@ final class MyViewController: BaseViewController {
         }
     }
     
+    private func requestLogoutAPI() {
+        MyAPI.shared.logout { result in
+            self.validateResult(result)
+        }
+    }
+    
     private func logout() {
+        requestLogoutAPI()
         User.shared.clearData()
         changeRootViewController(OnboardingLoginViewController())
     }
+    
+    
     
     //MARK: - Action Method
     

--- a/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
+++ b/ZOOC/ZOOC/Presentation/My/Controller/MyViewController.swift
@@ -38,7 +38,7 @@ final class MyViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        getMyPageAPI()
+        requestMyPageAPI()
     }
     
     //MARK: - Custom Method
@@ -54,7 +54,7 @@ final class MyViewController: BaseViewController {
         myView.myCollectionView.reloadData()
     }
     
-    func getMyPageAPI(){
+    func requestMyPageAPI(){
         MyAPI.shared.getMyPageData() { result in
             
             guard let result = self.validateResult(result) as? MyResult else { return }
@@ -65,6 +65,11 @@ final class MyViewController: BaseViewController {
             
             self.myView.myCollectionView.reloadData()
         }
+    }
+    
+    private func logout() {
+        User.shared.clearData()
+        changeRootViewController(OnboardingLoginViewController())
     }
     
     //MARK: - Action Method
@@ -182,6 +187,8 @@ extension MyViewController: SettingMenuTableViewCellDelegate {
             pushToNoticeSettingView()
         case 4:
             pushToAppInformationView()
+        case 5:
+            logout()
         default:
             break
         }

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingInviteFamilyCompletedViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingInviteFamilyCompletedViewController.swift
@@ -35,6 +35,14 @@ final class OnboardingInviteFamilyCompletedViewController: UIViewController{
         onboardingInviteCompletedFamilyView.startButton.addTarget(self, action: #selector(startButtonDidTap), for: .touchUpInside)
     }
     
+    
+    private func requestFCMTokenAPI() {
+        OnboardingAPI.shared.patchFCMToken(fcmToken: User.shared.fcmToken) { result in
+            self.changeRootViewController(ZoocTabBarController())
+        }
+    }
+    
+    
     //MARK: - Action Method
     
     @objc private func backButtonDidTap() {
@@ -42,6 +50,6 @@ final class OnboardingInviteFamilyCompletedViewController: UIViewController{
     }
     
     @objc private func startButtonDidTap(){
-        self.changeRootViewController(ZoocTabBarController())
+        requestFCMTokenAPI()
     }
 }

--- a/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Onboarding/Controller/OnboardingLoginViewController.swift
@@ -83,6 +83,11 @@ final class OnboardingLoginViewController: BaseViewController {
         target()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+    }
+    
     //MARK: - Custom Method
     
     private func target() {


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #110

### ✅ 작업한 내용
- 로그아웃 API 연동
- 가족 생성시 fcm갱신 API 연동

### ❗️PR Point
- 가족구성원이 글 올려도 아직 알림 안오네요
- ForeGround일때 푸시알람 안오네요
- 푸시알람 눌렀을 때 어느 화면 띄워줄지에 대한 처리도 해야겠네요 
- 
### 📸 스크린샷
- 스샷은 없다~

closed #110 
