### PR TITLE
[Feat] #184 - 알림조회에서 해당 게시글로 화면 전환 기능 구현

### DIFF
--- a/ZOOC/ZOOC/Data/Home/APIModel/HomeNoticeResult.swift
+++ b/ZOOC/ZOOC/Data/Home/APIModel/HomeNoticeResult.swift
@@ -10,8 +10,17 @@ import Foundation
 // MARK: - HomeAlarmResult
 
 struct HomeNoticeResult: Codable {
+    let recordID: Int
+    let petIDs: [Int]
     let writer: HomeNoticeWriter
-    let created_time: String
+    let createdTime: String
+    
+    enum CodingKeys: String, CodingKey {
+        case recordID = "record_id"
+        case petIDs = "pet_ids"
+        case writer
+        case createdTime = "created_time"
+    }
 }
 
 // MARK: - HomeAlarmWriter

--- a/ZOOC/ZOOC/Presentation/Archive/Controller/ArchiveViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Archive/Controller/ArchiveViewController.swift
@@ -166,7 +166,7 @@ final class ArchiveViewController : BaseViewController {
         }
         
         backButton.do {
-            $0.setImage(UIImage(systemName: "xmark"), for: .normal)
+            $0.setImage(Image.xmarkWhite, for: .normal)
             $0.tintColor = .white
         }
         
@@ -226,14 +226,14 @@ final class ArchiveViewController : BaseViewController {
         
         
         contentView.addSubviews(petImageView,
-                                 backButton,
-                                 etcButton,
-                                 dateLabel,
-                                 writerImageView,
-                                 writerNameLabel,
-                                 contentLabel,
-                                 lineView,
-                                 commentCollectionView)
+                                backButton,
+                                etcButton,
+                                dateLabel,
+                                writerImageView,
+                                writerNameLabel,
+                                contentLabel,
+                                lineView,
+                                commentCollectionView)
     }
     
     private func layout() {

--- a/ZOOC/ZOOC/Presentation/Home/Cell/HomeNoticeTableViewCell.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Cell/HomeNoticeTableViewCell.swift
@@ -89,7 +89,7 @@ final class HomeNoticeTableViewCell: UITableViewCell {
         }
         
         alarmContentLabel.text = "\(data.writer.nickName)님이 새로운 게시물을 올렸습니다."
-        createdTimeLabel.text = data.created_time
+        createdTimeLabel.text = data.createdTime
     }
 }
 

--- a/ZOOC/ZOOC/Presentation/Home/Controller/HomeNoticeViewController.swift
+++ b/ZOOC/ZOOC/Presentation/Home/Controller/HomeNoticeViewController.swift
@@ -67,13 +67,18 @@ final class HomeNoticeViewController: BaseViewController {
     }
 }
 
+//MARK: - UITableViewDelegate
+
 extension HomeNoticeViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 76
     }
 }
 
+//MARK: - UITableViewDataSource
+
 extension HomeNoticeViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return homeNoticeData.count
     }
@@ -84,6 +89,16 @@ extension HomeNoticeViewController: UITableViewDataSource {
         cell.selectionStyle = .none
         cell.dataBind(data: homeNoticeData[indexPath.row])
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let recordID = homeNoticeData[indexPath.row].recordID
+        let petID = homeNoticeData[indexPath.row].petIDs[0]
+        
+        let archiveVC = ArchiveViewController()
+        archiveVC.dataBind(recordID: recordID, petID: petID)
+        archiveVC.modalPresentationStyle = .fullScreen
+        present(archiveVC, animated: true)
     }
 }
 


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #184 

### ✅ 작업한 내용
- 준서가 수정해준 알림조회 API 적용하여 화면전환 기능 구현

### ❗️PR Point
- 알림 조회로 들어간 아카이빙 뷰에도 좌우 스와이핑 기능이 적용되어있다. 이 UX가 맞을까?

### 📸 스크린샷
![123](https://github.com/TeamZOOC/ZOOC-iOS/assets/57269348/ea9ded44-2de1-447c-9ae8-2b4146d441d2)



closed #184
